### PR TITLE
Multiples primary keys are not allowed

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,17 @@ package sqlparser
 
 import "fmt"
 
+// ErrSyntaxError indicates a syntax error.
+type ErrSyntaxError struct {
+	YaccError string
+	Position  int
+	Literal   string
+}
+
+func (e *ErrSyntaxError) Error() string {
+	return fmt.Sprintf("%s at position %d near '%s'", e.YaccError, e.Position, string(e.Literal))
+}
+
 // ErrKeywordIsNotAllowed indicates an error for keyword that is not allowed (eg CURRENT_TIME).
 type ErrKeywordIsNotAllowed struct {
 	Keyword string
@@ -82,4 +93,11 @@ type ErrGrantRepeatedPrivilege struct {
 
 func (e *ErrGrantRepeatedPrivilege) Error() string {
 	return fmt.Sprintf("repeated privilege: %s", e.Privilege)
+}
+
+// ErrMultiplePrimaryKey indicates a that a CREATE statement has more than one primary key.
+type ErrMultiplePrimaryKey struct{}
+
+func (e *ErrMultiplePrimaryKey) Error() string {
+	return "has more than one primary key"
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/mattn/go-sqlite3 v1.14.13
+	github.com/mattn/go-sqlite3 v1.14.15
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/mattn/go-sqlite3 v1.14.13 h1:1tj15ngiFfcZzii7yd82foL+ks+ouQcj8j/TPq3fk1I=
-github.com/mattn/go-sqlite3 v1.14.13/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=
+github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/lexer.go
+++ b/lexer.go
@@ -109,6 +109,9 @@ type Lexer struct {
 	lastToken int
 
 	ast *AST
+
+	// This is used to check if CREATE stmt has more than one primary key
+	createStmtHasPrimaryKey bool
 }
 
 // AddError keeps track of errors per statement for syntatically valid statements.

--- a/lexer.go
+++ b/lexer.go
@@ -2,7 +2,6 @@ package sqlparser
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -119,7 +118,7 @@ func (l *Lexer) AddError(err error) {
 
 // Error is used for syntatically not valid statements.
 func (l *Lexer) Error(e string) {
-	l.syntaxError = fmt.Errorf("%s at position %v near '%s'", e, l.position, string(l.literal))
+	l.syntaxError = &ErrSyntaxError{YaccError: e, Position: l.position, Literal: string(l.literal)}
 }
 
 func (l *Lexer) Lex(lval *yySymType) (token int) {

--- a/parser.go
+++ b/parser.go
@@ -21,8 +21,8 @@ func yyParsePooled(yylex yyLexer) int {
 }
 
 func Parse(statement string) (*AST, error) {
-	//yyErrorVerbose = true
-	//yyDebug = 4
+	// yyErrorVerbose = true
+	// yyDebug = 4
 
 	if len(statement) == 0 {
 		return &AST{}, nil
@@ -40,6 +40,7 @@ func Parse(statement string) (*AST, error) {
 
 	if len(lexer.errors) != 0 {
 		lexer.ast.Errors = lexer.errors
+		return lexer.ast, lexer.errors[0]
 	}
 	return lexer.ast, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -4657,6 +4657,7 @@ func TestCreateTableMultiplePrimaryKey(t *testing.T) {
 
 			_, err = db.Exec(tc.stmt)
 			require.Error(t, err)
+			require.ErrorContains(t, err, "has more than one primary key")
 		})
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -4617,13 +4617,50 @@ func TestParallel(t *testing.T) {
 
 func TestCreateTableMultiplePrimaryKey(t *testing.T) {
 	t.Parallel()
-	ast, err := Parse("CREATE TABLE t (a INT, b INT, PRIMARY KEY (a), PRIMARY KEY (b));")
-	require.Error(t, err)
-	require.Len(t, ast.Errors, 1)
 
-	var e *ErrMultiplePrimaryKey
-	require.ErrorAs(t, ast.Errors[0], &e)
-	require.ErrorAs(t, err, &e)
+	t.Run("table constraints", func(t *testing.T) {
+		t.Parallel()
+		ast, err := Parse("CREATE TABLE t (a INT, b INT, PRIMARY KEY (a), PRIMARY KEY (b));")
+		require.Error(t, err)
+		require.Len(t, ast.Errors, 1)
+
+		var e *ErrMultiplePrimaryKey
+		require.ErrorAs(t, ast.Errors[0], &e)
+		require.ErrorAs(t, err, &e)
+	})
+
+	t.Run("same column constraints", func(t *testing.T) {
+		t.Parallel()
+		ast, err := Parse("CREATE TABLE t (a INT PRIMARY KEY PRIMARY KEY);")
+		require.Error(t, err)
+		require.Len(t, ast.Errors, 1)
+
+		var e *ErrMultiplePrimaryKey
+		require.ErrorAs(t, ast.Errors[0], &e)
+		require.ErrorAs(t, err, &e)
+	})
+
+	t.Run("different columns constraints", func(t *testing.T) {
+		t.Parallel()
+		ast, err := Parse("CREATE TABLE t (a INT PRIMARY KEY, b INT PRIMARY KEY);")
+		require.Error(t, err)
+		require.Len(t, ast.Errors, 1)
+
+		var e *ErrMultiplePrimaryKey
+		require.ErrorAs(t, ast.Errors[0], &e)
+		require.ErrorAs(t, err, &e)
+	})
+
+	t.Run("mixed constraints", func(t *testing.T) {
+		t.Parallel()
+		ast, err := Parse("CREATE TABLE t (a INT PRIMARY KEY, b INT, PRIMARY KEY (b));")
+		require.Error(t, err)
+		require.Len(t, ast.Errors, 1)
+
+		var e *ErrMultiplePrimaryKey
+		require.ErrorAs(t, ast.Errors[0], &e)
+		require.ErrorAs(t, err, &e)
+	})
 }
 
 // This is not really a test. It just helps identify which SQLite keywords are reserved and which are not.

--- a/parser_test.go
+++ b/parser_test.go
@@ -4156,7 +4156,7 @@ func TestKeywordsNotAllowed(t *testing.T) {
 
 	for keyword := range keywordsNotAllowed {
 		ast, err := Parse(fmt.Sprintf("select %s from t", keyword))
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Len(t, ast.Errors, 1)
 
 		var e *ErrKeywordIsNotAllowed
@@ -4164,6 +4164,7 @@ func TestKeywordsNotAllowed(t *testing.T) {
 		if errors.As(ast.Errors[0], &e) {
 			require.Equal(t, keyword, e.Keyword)
 		}
+		require.ErrorAs(t, err, &e)
 	}
 }
 
@@ -4178,7 +4179,7 @@ func TestLimits(t *testing.T) {
 		}
 
 		ast, err := Parse(fmt.Sprintf("insert into t (a) values ('%s')", text))
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Len(t, ast.Errors, 1)
 
 		var e *ErrTextTooLong
@@ -4187,6 +4188,7 @@ func TestLimits(t *testing.T) {
 			require.Equal(t, len(text), e.Length)
 			require.Equal(t, MaxBlobLength, e.MaxAllowed)
 		}
+		require.ErrorAs(t, err, &e)
 	})
 
 	t.Run("max blob length", func(t *testing.T) {
@@ -4197,7 +4199,7 @@ func TestLimits(t *testing.T) {
 		}
 
 		ast, err := Parse(fmt.Sprintf("insert into t (a) values (x'%s')", blob))
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Len(t, ast.Errors, 1)
 
 		var e *ErrBlobTooBig
@@ -4206,6 +4208,7 @@ func TestLimits(t *testing.T) {
 			require.Equal(t, len(blob), e.Length)
 			require.Equal(t, MaxBlobLength, e.MaxAllowed)
 		}
+		require.ErrorAs(t, err, &e)
 	})
 
 	t.Run("max columns allowed", func(t *testing.T) {
@@ -4224,7 +4227,7 @@ func TestLimits(t *testing.T) {
 		columnsDef = append([]string{"a INT"}, columnsDef...)
 
 		ast, err := Parse(fmt.Sprintf("create table t (%s);", strings.Join(columnsDef, ", ")))
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Len(t, ast.Errors, 1)
 
 		var e *ErrTooManyColumns
@@ -4233,6 +4236,7 @@ func TestLimits(t *testing.T) {
 			require.Equal(t, len(columnsDef), e.ColumnCount)
 			require.Equal(t, MaxAllowedColumns, e.MaxAllowed)
 		}
+		require.ErrorAs(t, err, &e)
 	})
 }
 
@@ -4240,7 +4244,7 @@ func TestDisallowSubqueriesOnStatements(t *testing.T) {
 	t.Parallel()
 	t.Run("insert", func(t *testing.T) {
 		ast, err := Parse("insert into t (a) VALUES ((select 1 FROM t limit 1))")
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Len(t, ast.Errors, 1)
 
 		var e *ErrStatementContainsSubquery
@@ -4248,11 +4252,12 @@ func TestDisallowSubqueriesOnStatements(t *testing.T) {
 		if errors.As(ast.Errors[0], &e) {
 			require.Equal(t, "insert", e.StatementKind)
 		}
+		require.ErrorAs(t, err, &e)
 	})
 
 	t.Run("update update expr", func(t *testing.T) {
 		ast, err := Parse("update t set a = (select 1 FROM t limit 1)")
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Len(t, ast.Errors, 1)
 
 		var e *ErrStatementContainsSubquery
@@ -4260,11 +4265,12 @@ func TestDisallowSubqueriesOnStatements(t *testing.T) {
 		if errors.As(ast.Errors[0], &e) {
 			require.Equal(t, "update", e.StatementKind)
 		}
+		require.ErrorAs(t, err, &e)
 	})
 
 	t.Run("update where", func(t *testing.T) {
 		ast, err := Parse("update foo set a=1 where a=(select a from bar limit 1) and b=1")
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Len(t, ast.Errors, 1)
 
 		var e *ErrStatementContainsSubquery
@@ -4272,11 +4278,12 @@ func TestDisallowSubqueriesOnStatements(t *testing.T) {
 		if errors.As(ast.Errors[0], &e) {
 			require.Equal(t, "update", e.StatementKind)
 		}
+		require.ErrorAs(t, err, &e)
 	})
 
 	t.Run("delete", func(t *testing.T) {
 		ast, err := Parse("delete from t where a or (select 1 FROM t limit 1)")
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Len(t, ast.Errors, 1)
 
 		var e *ErrStatementContainsSubquery
@@ -4284,13 +4291,14 @@ func TestDisallowSubqueriesOnStatements(t *testing.T) {
 		if errors.As(ast.Errors[0], &e) {
 			require.Equal(t, "delete", e.StatementKind)
 		}
+		require.ErrorAs(t, err, &e)
 	})
 }
 
 func TestMultipleErrors(t *testing.T) {
 	t.Parallel()
 	ast, err := Parse("UPDATE t SET a = (select 1 from t2), b = unknown()")
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Len(t, ast.Errors, 1)
 
 	var e1 *ErrStatementContainsSubquery
@@ -4303,6 +4311,8 @@ func TestMultipleErrors(t *testing.T) {
 	if errors.As(ast.Errors[0], &e2) {
 		require.Equal(t, "unknown", e2.FunctionName)
 	}
+
+	require.ErrorAs(t, err, &e1)
 }
 
 func TestParallel(t *testing.T) {
@@ -4603,6 +4613,17 @@ func TestParallel(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestCreateTableMultiplePrimaryKey(t *testing.T) {
+	t.Parallel()
+	ast, err := Parse("CREATE TABLE t (a INT, b INT, PRIMARY KEY (a), PRIMARY KEY (b));")
+	require.Error(t, err)
+	require.Len(t, ast.Errors, 1)
+
+	var e *ErrMultiplePrimaryKey
+	require.ErrorAs(t, ast.Errors[0], &e)
+	require.ErrorAs(t, err, &e)
 }
 
 // This is not really a test. It just helps identify which SQLite keywords are reserved and which are not.

--- a/y.output
+++ b/y.output
@@ -34,7 +34,7 @@ state 1
 state 2
 	start:  stmts.    (1)
 
-	.  reduce 1 (src line 159)
+	.  reduce 1 (src line 161)
 
 
 state 3
@@ -42,7 +42,7 @@ state 3
 	semicolon_opt: .    (13)
 
 	';'  shift 21
-	.  reduce 13 (src line 224)
+	.  reduce 13 (src line 226)
 
 	semicolon_opt  goto 20
 
@@ -52,26 +52,26 @@ state 4
 	semicolon_opt: .    (13)
 
 	';'  shift 23
-	.  reduce 13 (src line 224)
+	.  reduce 13 (src line 226)
 
 	semicolon_opt  goto 22
 
 state 5
 	single_stmt:  select_stmt.    (4)
 
-	.  reduce 4 (src line 174)
+	.  reduce 4 (src line 176)
 
 
 state 6
 	single_stmt:  create_table_stmt.    (5)
 
-	.  reduce 5 (src line 179)
+	.  reduce 5 (src line 181)
 
 
 state 7
 	multi_stmts:  multi_stmt.    (6)
 
-	.  reduce 6 (src line 185)
+	.  reduce 6 (src line 187)
 
 
 state 8
@@ -80,7 +80,7 @@ state 8
 
 	DISTINCT  shift 25
 	ALL  shift 26
-	.  reduce 16 (src line 245)
+	.  reduce 16 (src line 247)
 
 	distinct_opt  goto 24
 
@@ -94,31 +94,31 @@ state 9
 state 10
 	multi_stmt:  insert_stmt.    (8)
 
-	.  reduce 8 (src line 196)
+	.  reduce 8 (src line 198)
 
 
 state 11
 	multi_stmt:  delete_stmt.    (9)
 
-	.  reduce 9 (src line 202)
+	.  reduce 9 (src line 204)
 
 
 state 12
 	multi_stmt:  update_stmt.    (10)
 
-	.  reduce 10 (src line 207)
+	.  reduce 10 (src line 209)
 
 
 state 13
 	multi_stmt:  grant_stmt.    (11)
 
-	.  reduce 11 (src line 212)
+	.  reduce 11 (src line 214)
 
 
 state 14
 	multi_stmt:  revoke_stmt.    (12)
 
-	.  reduce 12 (src line 217)
+	.  reduce 12 (src line 219)
 
 
 state 15
@@ -170,19 +170,19 @@ state 19
 state 20
 	stmts:  single_stmt semicolon_opt.    (2)
 
-	.  reduce 2 (src line 163)
+	.  reduce 2 (src line 165)
 
 
 state 21
 	semicolon_opt:  ';'.    (14)
 
-	.  reduce 14 (src line 226)
+	.  reduce 14 (src line 228)
 
 
 state 22
 	stmts:  multi_stmts semicolon_opt.    (3)
 
-	.  reduce 3 (src line 168)
+	.  reduce 3 (src line 170)
 
 
 state 23
@@ -194,7 +194,7 @@ state 23
 	UPDATE  shift 17
 	GRANT  shift 18
 	REVOKE  shift 19
-	.  reduce 14 (src line 226)
+	.  reduce 14 (src line 228)
 
 	multi_stmt  goto 39
 	insert_stmt  goto 10
@@ -244,13 +244,13 @@ state 24
 state 25
 	distinct_opt:  DISTINCT.    (17)
 
-	.  reduce 17 (src line 249)
+	.  reduce 17 (src line 251)
 
 
 state 26
 	distinct_opt:  ALL.    (18)
 
-	.  reduce 18 (src line 253)
+	.  reduce 18 (src line 255)
 
 
 state 27
@@ -291,13 +291,13 @@ state 30
 state 31
 	table_name:  identifier.    (68)
 
-	.  reduce 68 (src line 515)
+	.  reduce 68 (src line 517)
 
 
 state 32
 	identifier:  IDENTIFIER.    (231)
 
-	.  reduce 231 (src line 1322)
+	.  reduce 231 (src line 1330)
 
 
 state 33
@@ -312,25 +312,25 @@ state 33
 state 34
 	privileges:  privilege.    (226)
 
-	.  reduce 226 (src line 1289)
+	.  reduce 226 (src line 1297)
 
 
 state 35
 	privilege:  INSERT.    (228)
 
-	.  reduce 228 (src line 1307)
+	.  reduce 228 (src line 1315)
 
 
 state 36
 	privilege:  UPDATE.    (229)
 
-	.  reduce 229 (src line 1312)
+	.  reduce 229 (src line 1320)
 
 
 state 37
 	privilege:  DELETE.    (230)
 
-	.  reduce 230 (src line 1316)
+	.  reduce 230 (src line 1324)
 
 
 state 38
@@ -345,7 +345,7 @@ state 38
 state 39
 	multi_stmts:  multi_stmts ';' multi_stmt.    (7)
 
-	.  reduce 7 (src line 190)
+	.  reduce 7 (src line 192)
 
 
 state 40
@@ -361,13 +361,13 @@ state 40
 state 41
 	select_column_list:  select_column.    (19)
 
-	.  reduce 19 (src line 259)
+	.  reduce 19 (src line 261)
 
 
 state 42
 	select_column:  '*'.    (21)
 
-	.  reduce 21 (src line 269)
+	.  reduce 21 (src line 271)
 
 
 state 43
@@ -435,7 +435,7 @@ state 43
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 24 (src line 283)
+	.  reduce 24 (src line 285)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -456,13 +456,13 @@ state 44
 state 45
 	expr:  literal_value.    (69)
 
-	.  reduce 69 (src line 522)
+	.  reduce 69 (src line 524)
 
 
 state 46
 	expr:  column_name.    (70)
 
-	.  reduce 70 (src line 524)
+	.  reduce 70 (src line 526)
 
 
 state 47
@@ -593,7 +593,7 @@ state 50
 	'+'  shift 48
 	'-'  shift 47
 	'~'  shift 49
-	.  reduce 158 (src line 920)
+	.  reduce 158 (src line 922)
 
 	expr  goto 127
 	literal_value  goto 45
@@ -648,13 +648,13 @@ state 51
 state 52
 	expr:  subquery.    (104)
 
-	.  reduce 104 (src line 662)
+	.  reduce 104 (src line 664)
 
 
 state 53
 	expr:  exists_subquery.    (105)
 
-	.  reduce 105 (src line 666)
+	.  reduce 105 (src line 668)
 
 
 state 54
@@ -667,13 +667,13 @@ state 54
 state 55
 	expr:  function_call_keyword.    (107)
 
-	.  reduce 107 (src line 674)
+	.  reduce 107 (src line 676)
 
 
 state 56
 	expr:  function_call_generic.    (108)
 
-	.  reduce 108 (src line 675)
+	.  reduce 108 (src line 677)
 
 
 state 57
@@ -683,44 +683,44 @@ state 57
 	function_call_generic:  identifier.'(' '*' ')' filter_opt 
 
 	'('  shift 131
-	'.'  reduce 68 (src line 515)
-	.  reduce 115 (src line 712)
+	'.'  reduce 68 (src line 517)
+	.  reduce 115 (src line 714)
 
 
 state 58
 	literal_value:  numeric_literal.    (109)
 
-	.  reduce 109 (src line 678)
+	.  reduce 109 (src line 680)
 
 
 state 59
 	literal_value:  STRING.    (110)
 
-	.  reduce 110 (src line 683)
+	.  reduce 110 (src line 685)
 
 
 state 60
 	literal_value:  BLOBVAL.    (111)
 
-	.  reduce 111 (src line 691)
+	.  reduce 111 (src line 693)
 
 
 state 61
 	literal_value:  TRUE.    (112)
 
-	.  reduce 112 (src line 698)
+	.  reduce 112 (src line 700)
 
 
 state 62
 	literal_value:  FALSE.    (113)
 
-	.  reduce 113 (src line 702)
+	.  reduce 113 (src line 704)
 
 
 state 63
 	literal_value:  NULL.    (114)
 
-	.  reduce 114 (src line 706)
+	.  reduce 114 (src line 708)
 
 
 state 64
@@ -756,19 +756,19 @@ state 67
 state 68
 	numeric_literal:  INTEGRAL.    (195)
 
-	.  reduce 195 (src line 1090)
+	.  reduce 195 (src line 1092)
 
 
 state 69
 	numeric_literal:  FLOAT.    (196)
 
-	.  reduce 196 (src line 1095)
+	.  reduce 196 (src line 1097)
 
 
 state 70
 	numeric_literal:  HEXNUM.    (197)
 
-	.  reduce 197 (src line 1099)
+	.  reduce 197 (src line 1101)
 
 
 state 71
@@ -785,7 +785,7 @@ state 72
 
 	'('  shift 140
 	DEFAULT  shift 139
-	.  reduce 210 (src line 1173)
+	.  reduce 210 (src line 1181)
 
 	column_name_list_opt  goto 138
 
@@ -794,7 +794,7 @@ state 73
 	where_opt: .    (47)
 
 	WHERE  shift 142
-	.  reduce 47 (src line 411)
+	.  reduce 47 (src line 413)
 
 	where_opt  goto 141
 
@@ -845,7 +845,7 @@ state 78
 	where_opt: .    (47)
 
 	WHERE  shift 142
-	.  reduce 47 (src line 411)
+	.  reduce 47 (src line 413)
 
 	where_opt  goto 153
 
@@ -903,7 +903,7 @@ state 80
 state 81
 	select_column:  expr as_column_opt.    (22)
 
-	.  reduce 22 (src line 274)
+	.  reduce 22 (src line 276)
 
 
 state 82
@@ -1542,13 +1542,13 @@ state 99
 state 100
 	expr:  expr ISNULL.    (95)
 
-	.  reduce 95 (src line 626)
+	.  reduce 95 (src line 628)
 
 
 state 101
 	expr:  expr NOTNULL.    (96)
 
-	.  reduce 96 (src line 630)
+	.  reduce 96 (src line 632)
 
 
 state 102
@@ -1625,7 +1625,7 @@ state 105
 state 106
 	as_column_opt:  col_alias.    (25)
 
-	.  reduce 25 (src line 287)
+	.  reduce 25 (src line 289)
 
 
 state 107
@@ -1641,79 +1641,79 @@ state 107
 state 108
 	cmp_op:  '='.    (118)
 
-	.  reduce 118 (src line 730)
+	.  reduce 118 (src line 732)
 
 
 state 109
 	cmp_op:  NE.    (119)
 
-	.  reduce 119 (src line 735)
+	.  reduce 119 (src line 737)
 
 
 state 110
 	cmp_op:  REGEXP.    (120)
 
-	.  reduce 120 (src line 739)
+	.  reduce 120 (src line 741)
 
 
 state 111
 	cmp_op:  GLOB.    (122)
 
-	.  reduce 122 (src line 747)
+	.  reduce 122 (src line 749)
 
 
 state 112
 	cmp_op:  MATCH.    (124)
 
-	.  reduce 124 (src line 755)
+	.  reduce 124 (src line 757)
 
 
 state 113
 	cmp_inequality_op:  '<'.    (126)
 
-	.  reduce 126 (src line 765)
+	.  reduce 126 (src line 767)
 
 
 state 114
 	cmp_inequality_op:  '>'.    (127)
 
-	.  reduce 127 (src line 770)
+	.  reduce 127 (src line 772)
 
 
 state 115
 	cmp_inequality_op:  LE.    (128)
 
-	.  reduce 128 (src line 774)
+	.  reduce 128 (src line 776)
 
 
 state 116
 	cmp_inequality_op:  GE.    (129)
 
-	.  reduce 129 (src line 778)
+	.  reduce 129 (src line 780)
 
 
 state 117
 	like_op:  LIKE.    (130)
 
-	.  reduce 130 (src line 784)
+	.  reduce 130 (src line 786)
 
 
 state 118
 	between_op:  BETWEEN.    (132)
 
-	.  reduce 132 (src line 795)
+	.  reduce 132 (src line 797)
 
 
 state 119
 	col_alias:  identifier.    (27)
 
-	.  reduce 27 (src line 296)
+	.  reduce 27 (src line 298)
 
 
 state 120
 	col_alias:  STRING.    (28)
 
-	.  reduce 28 (src line 301)
+	.  reduce 28 (src line 303)
 
 
 state 121
@@ -1757,7 +1757,7 @@ state 122
 	expr:  expr.IN col_tuple 
 	expr:  expr.NOT IN col_tuple 
 
-	.  reduce 88 (src line 594)
+	.  reduce 88 (src line 596)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -1801,7 +1801,7 @@ state 124
 	expr:  expr.IN col_tuple 
 	expr:  expr.NOT IN col_tuple 
 
-	.  reduce 89 (src line 602)
+	.  reduce 89 (src line 604)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -1838,7 +1838,7 @@ state 125
 	expr:  expr.IN col_tuple 
 	expr:  expr.NOT IN col_tuple 
 
-	.  reduce 90 (src line 606)
+	.  reduce 90 (src line 608)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -1915,7 +1915,7 @@ state 127
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 159 (src line 924)
+	.  reduce 159 (src line 926)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2040,14 +2040,14 @@ state 131
 
 	DISTINCT  shift 203
 	'*'  shift 202
-	.  reduce 150 (src line 879)
+	.  reduce 150 (src line 881)
 
 	distinct_function_opt  goto 201
 
 state 132
 	exists_subquery:  EXISTS subquery.    (143)
 
-	.  reduce 143 (src line 836)
+	.  reduce 143 (src line 838)
 
 
 state 133
@@ -2175,7 +2175,7 @@ state 140
 state 141
 	delete_stmt:  DELETE FROM table_name where_opt.    (214)
 
-	.  reduce 214 (src line 1195)
+	.  reduce 214 (src line 1203)
 
 
 state 142
@@ -2218,7 +2218,7 @@ state 143
 	where_opt: .    (47)
 
 	WHERE  shift 142
-	.  reduce 47 (src line 411)
+	.  reduce 47 (src line 413)
 
 	where_opt  goto 215
 
@@ -2227,19 +2227,19 @@ state 144
 	common_update_list:  common_update_list.',' update_expression 
 
 	','  shift 216
-	.  reduce 216 (src line 1215)
+	.  reduce 216 (src line 1223)
 
 
 state 145
 	update_list:  paren_update_list.    (217)
 
-	.  reduce 217 (src line 1220)
+	.  reduce 217 (src line 1228)
 
 
 state 146
 	common_update_list:  update_expression.    (218)
 
-	.  reduce 218 (src line 1226)
+	.  reduce 218 (src line 1234)
 
 
 state 147
@@ -2262,7 +2262,7 @@ state 148
 state 149
 	column_name:  identifier.    (115)
 
-	.  reduce 115 (src line 712)
+	.  reduce 115 (src line 714)
 
 
 state 150
@@ -2275,7 +2275,7 @@ state 150
 state 151
 	privileges:  privileges ',' privilege.    (227)
 
-	.  reduce 227 (src line 1296)
+	.  reduce 227 (src line 1304)
 
 
 state 152
@@ -2290,14 +2290,14 @@ state 153
 	group_by_opt: .    (49)
 
 	GROUP  shift 222
-	.  reduce 49 (src line 421)
+	.  reduce 49 (src line 423)
 
 	group_by_opt  goto 221
 
 state 154
 	select_column_list:  select_column_list ',' select_column.    (20)
 
-	.  reduce 20 (src line 264)
+	.  reduce 20 (src line 266)
 
 
 state 155
@@ -2305,7 +2305,7 @@ state 155
 	table_expr_list:  table_expr_list.',' table_expr 
 
 	','  shift 223
-	.  reduce 29 (src line 307)
+	.  reduce 29 (src line 309)
 
 
 state 156
@@ -2313,7 +2313,7 @@ state 156
 	join_clause:  join_clause.JOIN table_expr join_constraint 
 
 	JOIN  shift 224
-	.  reduce 30 (src line 312)
+	.  reduce 30 (src line 314)
 
 
 state 157
@@ -2321,7 +2321,7 @@ state 157
 	join_clause:  table_expr.JOIN table_expr join_constraint 
 
 	JOIN  shift 225
-	.  reduce 31 (src line 318)
+	.  reduce 31 (src line 320)
 
 
 state 158
@@ -2331,7 +2331,7 @@ state 158
 	IDENTIFIER  shift 32
 	STRING  shift 230
 	AS  shift 228
-	.  reduce 37 (src line 348)
+	.  reduce 37 (src line 350)
 
 	as_table_opt  goto 226
 	table_alias  goto 227
@@ -2391,7 +2391,7 @@ state 160
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 72 (src line 530)
+	.  reduce 72 (src line 532)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2435,7 +2435,7 @@ state 161
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 73 (src line 534)
+	.  reduce 73 (src line 536)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2476,7 +2476,7 @@ state 162
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 74 (src line 538)
+	.  reduce 74 (src line 540)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2517,7 +2517,7 @@ state 163
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 75 (src line 542)
+	.  reduce 75 (src line 544)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2558,7 +2558,7 @@ state 164
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 76 (src line 546)
+	.  reduce 76 (src line 548)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2604,7 +2604,7 @@ state 165
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 77 (src line 550)
+	.  reduce 77 (src line 552)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2650,7 +2650,7 @@ state 166
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 78 (src line 554)
+	.  reduce 78 (src line 556)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2696,7 +2696,7 @@ state 167
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 79 (src line 558)
+	.  reduce 79 (src line 560)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2742,7 +2742,7 @@ state 168
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 80 (src line 562)
+	.  reduce 80 (src line 564)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2780,7 +2780,7 @@ state 169
 	expr:  expr.NOT IN col_tuple 
 
 	COLLATE  shift 104
-	.  reduce 81 (src line 566)
+	.  reduce 81 (src line 568)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2818,7 +2818,7 @@ state 170
 	expr:  expr.NOT IN col_tuple 
 
 	COLLATE  shift 104
-	.  reduce 82 (src line 570)
+	.  reduce 82 (src line 572)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2856,7 +2856,7 @@ state 171
 	expr:  expr.NOT IN col_tuple 
 
 	COLLATE  shift 104
-	.  reduce 83 (src line 574)
+	.  reduce 83 (src line 576)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2910,7 +2910,7 @@ state 172
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 84 (src line 578)
+	.  reduce 84 (src line 580)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2960,7 +2960,7 @@ state 173
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 85 (src line 582)
+	.  reduce 85 (src line 584)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3016,7 +3016,7 @@ state 174
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 86 (src line 586)
+	.  reduce 86 (src line 588)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3082,7 +3082,7 @@ state 175
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 91 (src line 610)
+	.  reduce 91 (src line 612)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3149,7 +3149,7 @@ state 176
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 92 (src line 614)
+	.  reduce 92 (src line 616)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3203,7 +3203,7 @@ state 177
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 93 (src line 618)
+	.  reduce 93 (src line 620)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3248,7 +3248,7 @@ state 178
 state 179
 	expr:  expr NOT NULL.    (97)
 
-	.  reduce 97 (src line 634)
+	.  reduce 97 (src line 636)
 
 
 state 180
@@ -3263,31 +3263,31 @@ state 180
 state 181
 	cmp_op:  NOT REGEXP.    (121)
 
-	.  reduce 121 (src line 743)
+	.  reduce 121 (src line 745)
 
 
 state 182
 	cmp_op:  NOT GLOB.    (123)
 
-	.  reduce 123 (src line 751)
+	.  reduce 123 (src line 753)
 
 
 state 183
 	cmp_op:  NOT MATCH.    (125)
 
-	.  reduce 125 (src line 759)
+	.  reduce 125 (src line 761)
 
 
 state 184
 	like_op:  NOT LIKE.    (131)
 
-	.  reduce 131 (src line 789)
+	.  reduce 131 (src line 791)
 
 
 state 185
 	between_op:  NOT BETWEEN.    (133)
 
-	.  reduce 133 (src line 800)
+	.  reduce 133 (src line 802)
 
 
 state 186
@@ -3362,13 +3362,13 @@ state 186
 state 187
 	expr:  expr COLLATE identifier.    (100)
 
-	.  reduce 100 (src line 646)
+	.  reduce 100 (src line 648)
 
 
 state 188
 	expr:  expr IN col_tuple.    (102)
 
-	.  reduce 102 (src line 654)
+	.  reduce 102 (src line 656)
 
 
 state 189
@@ -3415,25 +3415,25 @@ state 189
 state 190
 	col_tuple:  subquery.    (140)
 
-	.  reduce 140 (src line 819)
+	.  reduce 140 (src line 821)
 
 
 state 191
 	as_column_opt:  AS col_alias.    (26)
 
-	.  reduce 26 (src line 291)
+	.  reduce 26 (src line 293)
 
 
 state 192
 	select_column:  table_name '.' '*'.    (23)
 
-	.  reduce 23 (src line 278)
+	.  reduce 23 (src line 280)
 
 
 state 193
 	expr:  table_name '.' column_name.    (71)
 
-	.  reduce 71 (src line 525)
+	.  reduce 71 (src line 527)
 
 
 state 194
@@ -3452,7 +3452,7 @@ state 195
 
 	WHEN  shift 197
 	ELSE  shift 243
-	.  reduce 163 (src line 947)
+	.  reduce 163 (src line 949)
 
 	else_expr_opt  goto 241
 	when  goto 242
@@ -3460,7 +3460,7 @@ state 195
 state 196
 	when_expr_list:  when.    (161)
 
-	.  reduce 161 (src line 937)
+	.  reduce 161 (src line 939)
 
 
 state 197
@@ -3501,13 +3501,13 @@ state 197
 state 198
 	expr:  '(' expr ')'.    (101)
 
-	.  reduce 101 (src line 650)
+	.  reduce 101 (src line 652)
 
 
 state 199
 	subquery:  '(' select_stmt ')'.    (142)
 
-	.  reduce 142 (src line 829)
+	.  reduce 142 (src line 831)
 
 
 state 200
@@ -3602,7 +3602,7 @@ state 201
 	'+'  shift 48
 	'-'  shift 47
 	'~'  shift 49
-	.  reduce 154 (src line 900)
+	.  reduce 154 (src line 902)
 
 	expr  goto 240
 	literal_value  goto 45
@@ -3627,13 +3627,13 @@ state 202
 state 203
 	distinct_function_opt:  DISTINCT.    (151)
 
-	.  reduce 151 (src line 883)
+	.  reduce 151 (src line 885)
 
 
 state 204
 	exists_subquery:  NOT EXISTS subquery.    (144)
 
-	.  reduce 144 (src line 841)
+	.  reduce 144 (src line 843)
 
 
 state 205
@@ -3781,7 +3781,7 @@ state 207
 	table_constraint_list_opt: .    (201)
 
 	','  shift 252
-	.  reduce 201 (src line 1119)
+	.  reduce 201 (src line 1121)
 
 	table_constraint_list  goto 253
 	table_constraint_list_opt  goto 251
@@ -3789,7 +3789,7 @@ state 207
 state 208
 	column_def_list:  column_def.    (166)
 
-	.  reduce 166 (src line 967)
+	.  reduce 166 (src line 969)
 
 
 state 209
@@ -3816,7 +3816,7 @@ state 210
 state 211
 	insert_stmt:  INSERT INTO table_name DEFAULT VALUES.    (209)
 
-	.  reduce 209 (src line 1167)
+	.  reduce 209 (src line 1175)
 
 
 state 212
@@ -3831,7 +3831,7 @@ state 212
 state 213
 	column_name_list:  column_name.    (116)
 
-	.  reduce 116 (src line 719)
+	.  reduce 116 (src line 721)
 
 
 state 214
@@ -3895,7 +3895,7 @@ state 214
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 48 (src line 415)
+	.  reduce 48 (src line 417)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3905,7 +3905,7 @@ state 214
 state 215
 	update_stmt:  UPDATE table_name SET update_list where_opt.    (215)
 
-	.  reduce 215 (src line 1205)
+	.  reduce 215 (src line 1213)
 
 
 state 216
@@ -3983,7 +3983,7 @@ state 221
 	having_opt: .    (51)
 
 	HAVING  shift 272
-	.  reduce 51 (src line 431)
+	.  reduce 51 (src line 433)
 
 	having_opt  goto 271
 
@@ -4030,13 +4030,13 @@ state 225
 state 226
 	table_expr:  table_name as_table_opt.    (33)
 
-	.  reduce 33 (src line 329)
+	.  reduce 33 (src line 331)
 
 
 state 227
 	as_table_opt:  table_alias.    (38)
 
-	.  reduce 38 (src line 352)
+	.  reduce 38 (src line 354)
 
 
 state 228
@@ -4052,13 +4052,13 @@ state 228
 state 229
 	table_alias:  identifier.    (40)
 
-	.  reduce 40 (src line 361)
+	.  reduce 40 (src line 363)
 
 
 state 230
 	table_alias:  STRING.    (41)
 
-	.  reduce 41 (src line 366)
+	.  reduce 41 (src line 368)
 
 
 state 231
@@ -4168,7 +4168,7 @@ state 235
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 94 (src line 622)
+	.  reduce 94 (src line 624)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -4178,7 +4178,7 @@ state 235
 state 236
 	expr:  expr NOT IN col_tuple.    (103)
 
-	.  reduce 103 (src line 658)
+	.  reduce 103 (src line 660)
 
 
 state 237
@@ -4219,7 +4219,7 @@ state 237
 state 238
 	col_tuple:  '(' ')'.    (139)
 
-	.  reduce 139 (src line 814)
+	.  reduce 139 (src line 816)
 
 
 state 239
@@ -4292,7 +4292,7 @@ state 240
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 152 (src line 889)
+	.  reduce 152 (src line 891)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -4309,7 +4309,7 @@ state 241
 state 242
 	when_expr_list:  when_expr_list when.    (162)
 
-	.  reduce 162 (src line 942)
+	.  reduce 162 (src line 944)
 
 
 state 243
@@ -4440,7 +4440,7 @@ state 247
 	expr_list_opt:  expr_list.    (155)
 
 	','  shift 284
-	.  reduce 155 (src line 904)
+	.  reduce 155 (src line 906)
 
 
 state 248
@@ -4448,7 +4448,7 @@ state 248
 	filter_opt: .    (156)
 
 	FILTER  shift 296
-	.  reduce 156 (src line 910)
+	.  reduce 156 (src line 912)
 
 	filter_opt  goto 295
 
@@ -4537,7 +4537,7 @@ state 252
 
 	IDENTIFIER  shift 32
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1054)
+	.  reduce 188 (src line 1056)
 
 	column_name  goto 209
 	constraint_name  goto 302
@@ -4550,7 +4550,7 @@ state 253
 	table_constraint_list:  table_constraint_list.',' table_constraint 
 
 	','  shift 304
-	.  reduce 202 (src line 1123)
+	.  reduce 202 (src line 1125)
 
 
 state 254
@@ -4558,10 +4558,10 @@ state 254
 	column_constraints_opt: .    (175)
 	constraint_name: .    (188)
 
-	','  reduce 175 (src line 994)
-	')'  reduce 175 (src line 994)
+	','  reduce 175 (src line 996)
+	')'  reduce 175 (src line 996)
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1054)
+	.  reduce 188 (src line 1056)
 
 	constraint_name  goto 308
 	column_constraint  goto 307
@@ -4571,37 +4571,37 @@ state 254
 state 255
 	type_name:  INT.    (169)
 
-	.  reduce 169 (src line 985)
+	.  reduce 169 (src line 987)
 
 
 state 256
 	type_name:  INTEGER.    (170)
 
-	.  reduce 170 (src line 987)
+	.  reduce 170 (src line 989)
 
 
 state 257
 	type_name:  REAL.    (171)
 
-	.  reduce 171 (src line 988)
+	.  reduce 171 (src line 990)
 
 
 state 258
 	type_name:  TEXT.    (172)
 
-	.  reduce 172 (src line 989)
+	.  reduce 172 (src line 991)
 
 
 state 259
 	type_name:  BLOB.    (173)
 
-	.  reduce 173 (src line 990)
+	.  reduce 173 (src line 992)
 
 
 state 260
 	type_name:  ANY.    (174)
 
-	.  reduce 174 (src line 991)
+	.  reduce 174 (src line 993)
 
 
 state 261
@@ -4609,7 +4609,7 @@ state 261
 	insert_rows:  insert_rows.',' '(' expr_list ')' 
 
 	','  shift 309
-	.  reduce 208 (src line 1155)
+	.  reduce 208 (src line 1163)
 
 
 state 262
@@ -4660,13 +4660,13 @@ state 263
 state 264
 	column_name_list_opt:  '(' column_name_list ')'.    (211)
 
-	.  reduce 211 (src line 1177)
+	.  reduce 211 (src line 1185)
 
 
 state 265
 	common_update_list:  common_update_list ',' update_expression.    (219)
 
-	.  reduce 219 (src line 1234)
+	.  reduce 219 (src line 1242)
 
 
 state 266
@@ -4737,7 +4737,7 @@ state 267
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 221 (src line 1256)
+	.  reduce 221 (src line 1264)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -4749,13 +4749,13 @@ state 268
 	roles:  roles.',' STRING 
 
 	','  shift 313
-	.  reduce 222 (src line 1263)
+	.  reduce 222 (src line 1271)
 
 
 state 269
 	roles:  STRING.    (224)
 
-	.  reduce 224 (src line 1278)
+	.  reduce 224 (src line 1286)
 
 
 state 270
@@ -4763,7 +4763,7 @@ state 270
 	roles:  roles.',' STRING 
 
 	','  shift 313
-	.  reduce 223 (src line 1270)
+	.  reduce 223 (src line 1278)
 
 
 state 271
@@ -4771,7 +4771,7 @@ state 271
 	order_by_opt: .    (53)
 
 	ORDER  shift 315
-	.  reduce 53 (src line 441)
+	.  reduce 53 (src line 443)
 
 	order_by_opt  goto 314
 
@@ -4849,7 +4849,7 @@ state 273
 state 274
 	table_expr_list:  table_expr_list ',' table_expr.    (32)
 
-	.  reduce 32 (src line 323)
+	.  reduce 32 (src line 325)
 
 
 state 275
@@ -4858,7 +4858,7 @@ state 275
 
 	ON  shift 319
 	USING  shift 320
-	.  reduce 44 (src line 397)
+	.  reduce 44 (src line 399)
 
 	join_constraint  goto 318
 
@@ -4868,14 +4868,14 @@ state 276
 
 	ON  shift 319
 	USING  shift 320
-	.  reduce 44 (src line 397)
+	.  reduce 44 (src line 399)
 
 	join_constraint  goto 321
 
 state 277
 	as_table_opt:  AS table_alias.    (39)
 
-	.  reduce 39 (src line 356)
+	.  reduce 39 (src line 358)
 
 
 state 278
@@ -4885,7 +4885,7 @@ state 278
 	IDENTIFIER  shift 32
 	STRING  shift 230
 	AS  shift 228
-	.  reduce 37 (src line 348)
+	.  reduce 37 (src line 350)
 
 	as_table_opt  goto 322
 	table_alias  goto 227
@@ -4894,13 +4894,13 @@ state 278
 state 279
 	table_expr:  '(' table_expr_list ')'.    (35)
 
-	.  reduce 35 (src line 338)
+	.  reduce 35 (src line 340)
 
 
 state 280
 	table_expr:  '(' join_clause ')'.    (36)
 
-	.  reduce 36 (src line 342)
+	.  reduce 36 (src line 344)
 
 
 state 281
@@ -4950,7 +4950,7 @@ state 281
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 87 (src line 590)
+	.  reduce 87 (src line 592)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5004,7 +5004,7 @@ state 282
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 98 (src line 638)
+	.  reduce 98 (src line 640)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5014,7 +5014,7 @@ state 282
 state 283
 	col_tuple:  '(' expr_list ')'.    (141)
 
-	.  reduce 141 (src line 823)
+	.  reduce 141 (src line 825)
 
 
 state 284
@@ -5055,7 +5055,7 @@ state 284
 state 285
 	expr:  CASE expr_opt when_expr_list else_expr_opt END.    (99)
 
-	.  reduce 99 (src line 642)
+	.  reduce 99 (src line 644)
 
 
 state 286
@@ -5119,7 +5119,7 @@ state 286
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 164 (src line 951)
+	.  reduce 164 (src line 953)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5171,31 +5171,31 @@ state 288
 state 289
 	convert_type:  NONE.    (134)
 
-	.  reduce 134 (src line 806)
+	.  reduce 134 (src line 808)
 
 
 state 290
 	convert_type:  TEXT.    (135)
 
-	.  reduce 135 (src line 808)
+	.  reduce 135 (src line 810)
 
 
 state 291
 	convert_type:  REAL.    (136)
 
-	.  reduce 136 (src line 809)
+	.  reduce 136 (src line 811)
 
 
 state 292
 	convert_type:  INTEGER.    (137)
 
-	.  reduce 137 (src line 810)
+	.  reduce 137 (src line 812)
 
 
 state 293
 	convert_type:  NUMERIC.    (138)
 
-	.  reduce 138 (src line 811)
+	.  reduce 138 (src line 813)
 
 
 state 294
@@ -5203,14 +5203,14 @@ state 294
 	filter_opt: .    (156)
 
 	FILTER  shift 296
-	.  reduce 156 (src line 910)
+	.  reduce 156 (src line 912)
 
 	filter_opt  goto 326
 
 state 295
 	function_call_generic:  identifier '(' '*' ')' filter_opt.    (149)
 
-	.  reduce 149 (src line 870)
+	.  reduce 149 (src line 872)
 
 
 state 296
@@ -5363,19 +5363,19 @@ state 298
 state 299
 	create_table_stmt:  CREATE TABLE table_name '(' column_def_list table_constraint_list_opt ')'.    (165)
 
-	.  reduce 165 (src line 957)
+	.  reduce 165 (src line 959)
 
 
 state 300
 	column_def_list:  column_def_list ',' column_def.    (167)
 
-	.  reduce 167 (src line 972)
+	.  reduce 167 (src line 974)
 
 
 state 301
 	table_constraint_list:  ',' table_constraint.    (203)
 
-	.  reduce 203 (src line 1129)
+	.  reduce 203 (src line 1131)
 
 
 state 302
@@ -5402,7 +5402,7 @@ state 304
 	constraint_name: .    (188)
 
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1054)
+	.  reduce 188 (src line 1056)
 
 	constraint_name  goto 302
 	table_constraint  goto 335
@@ -5410,7 +5410,7 @@ state 304
 state 305
 	column_def:  column_name type_name column_constraints_opt.    (168)
 
-	.  reduce 168 (src line 978)
+	.  reduce 168 (src line 980)
 
 
 state 306
@@ -5418,10 +5418,10 @@ state 306
 	column_constraints:  column_constraints.column_constraint 
 	constraint_name: .    (188)
 
-	','  reduce 176 (src line 998)
-	')'  reduce 176 (src line 998)
+	','  reduce 176 (src line 1000)
+	')'  reduce 176 (src line 1000)
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1054)
+	.  reduce 188 (src line 1056)
 
 	constraint_name  goto 308
 	column_constraint  goto 336
@@ -5429,7 +5429,7 @@ state 306
 state 307
 	column_constraints:  column_constraint.    (177)
 
-	.  reduce 177 (src line 1004)
+	.  reduce 177 (src line 1006)
 
 
 state 308
@@ -5472,7 +5472,7 @@ state 310
 state 311
 	column_name_list:  column_name_list ',' column_name.    (117)
 
-	.  reduce 117 (src line 724)
+	.  reduce 117 (src line 726)
 
 
 state 312
@@ -5494,7 +5494,7 @@ state 314
 	limit_opt: .    (64)
 
 	LIMIT  shift 349
-	.  reduce 64 (src line 497)
+	.  reduce 64 (src line 499)
 
 	limit_opt  goto 348
 
@@ -5566,7 +5566,7 @@ state 316
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 52 (src line 435)
+	.  reduce 52 (src line 437)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5578,13 +5578,13 @@ state 317
 	expr_list:  expr_list.',' expr 
 
 	','  shift 284
-	.  reduce 50 (src line 425)
+	.  reduce 50 (src line 427)
 
 
 state 318
 	join_clause:  join_clause JOIN table_expr join_constraint.    (43)
 
-	.  reduce 43 (src line 384)
+	.  reduce 43 (src line 386)
 
 
 state 319
@@ -5632,13 +5632,13 @@ state 320
 state 321
 	join_clause:  table_expr JOIN table_expr join_constraint.    (42)
 
-	.  reduce 42 (src line 372)
+	.  reduce 42 (src line 374)
 
 
 state 322
 	table_expr:  '(' select_stmt ')' as_table_opt.    (34)
 
-	.  reduce 34 (src line 334)
+	.  reduce 34 (src line 336)
 
 
 state 323
@@ -5702,7 +5702,7 @@ state 323
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 153 (src line 894)
+	.  reduce 153 (src line 896)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5770,7 +5770,7 @@ state 324
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 160 (src line 930)
+	.  reduce 160 (src line 932)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5780,13 +5780,13 @@ state 324
 state 325
 	expr:  CAST '(' expr AS convert_type ')'.    (106)
 
-	.  reduce 106 (src line 670)
+	.  reduce 106 (src line 672)
 
 
 state 326
 	function_call_generic:  identifier '(' distinct_function_opt expr_list_opt ')' filter_opt.    (148)
 
-	.  reduce 148 (src line 862)
+	.  reduce 148 (src line 864)
 
 
 state 327
@@ -5799,13 +5799,13 @@ state 327
 state 328
 	function_call_keyword:  GLOB '(' expr ',' expr ')'.    (145)
 
-	.  reduce 145 (src line 847)
+	.  reduce 145 (src line 849)
 
 
 state 329
 	function_call_keyword:  LIKE '(' expr ',' expr ')'.    (146)
 
-	.  reduce 146 (src line 852)
+	.  reduce 146 (src line 854)
 
 
 state 330
@@ -5867,19 +5867,19 @@ state 333
 state 334
 	constraint_name:  CONSTRAINT identifier.    (189)
 
-	.  reduce 189 (src line 1058)
+	.  reduce 189 (src line 1060)
 
 
 state 335
 	table_constraint_list:  table_constraint_list ',' table_constraint.    (204)
 
-	.  reduce 204 (src line 1134)
+	.  reduce 204 (src line 1139)
 
 
 state 336
 	column_constraints:  column_constraints column_constraint.    (178)
 
-	.  reduce 178 (src line 1009)
+	.  reduce 178 (src line 1011)
 
 
 state 337
@@ -5899,7 +5899,7 @@ state 338
 state 339
 	column_constraint:  constraint_name UNIQUE.    (181)
 
-	.  reduce 181 (src line 1024)
+	.  reduce 181 (src line 1026)
 
 
 state 340
@@ -5984,7 +5984,7 @@ state 344
 state 345
 	insert_rows:  '(' expr_list ')'.    (212)
 
-	.  reduce 212 (src line 1184)
+	.  reduce 212 (src line 1192)
 
 
 state 346
@@ -6026,13 +6026,13 @@ state 346
 state 347
 	roles:  roles ',' STRING.    (225)
 
-	.  reduce 225 (src line 1283)
+	.  reduce 225 (src line 1291)
 
 
 state 348
 	select_stmt:  SELECT distinct_opt select_column_list from_clause where_opt group_by_opt having_opt order_by_opt limit_opt.    (15)
 
-	.  reduce 15 (src line 230)
+	.  reduce 15 (src line 232)
 
 
 state 349
@@ -6170,7 +6170,7 @@ state 351
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 45 (src line 401)
+	.  reduce 45 (src line 403)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -6349,14 +6349,14 @@ state 358
 
 	ASC  shift 381
 	DESC  shift 382
-	.  reduce 190 (src line 1064)
+	.  reduce 190 (src line 1066)
 
 	primary_key_order  goto 380
 
 state 359
 	column_constraint:  constraint_name NOT NULL.    (180)
 
-	.  reduce 180 (src line 1020)
+	.  reduce 180 (src line 1022)
 
 
 state 360
@@ -6432,13 +6432,13 @@ state 361
 state 362
 	column_constraint:  constraint_name DEFAULT literal_value.    (184)
 
-	.  reduce 184 (src line 1036)
+	.  reduce 184 (src line 1038)
 
 
 state 363
 	column_constraint:  constraint_name DEFAULT signed_number.    (185)
 
-	.  reduce 185 (src line 1040)
+	.  reduce 185 (src line 1042)
 
 
 state 364
@@ -6586,7 +6586,7 @@ state 370
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 65 (src line 501)
+	.  reduce 65 (src line 503)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -6598,13 +6598,13 @@ state 371
 	order_list:  order_list.',' ordering_term 
 
 	','  shift 393
-	.  reduce 54 (src line 445)
+	.  reduce 54 (src line 447)
 
 
 state 372
 	order_list:  ordering_term.    (55)
 
-	.  reduce 55 (src line 451)
+	.  reduce 55 (src line 453)
 
 
 state 373
@@ -6671,7 +6671,7 @@ state 373
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 58 (src line 469)
+	.  reduce 58 (src line 471)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -6760,7 +6760,7 @@ state 375
 state 376
 	function_call_keyword:  LIKE '(' expr ',' expr ',' expr ')'.    (147)
 
-	.  reduce 147 (src line 856)
+	.  reduce 147 (src line 858)
 
 
 state 377
@@ -6854,19 +6854,19 @@ state 379
 state 380
 	column_constraint:  constraint_name PRIMARY KEY primary_key_order.    (179)
 
-	.  reduce 179 (src line 1015)
+	.  reduce 179 (src line 1017)
 
 
 state 381
 	primary_key_order:  ASC.    (191)
 
-	.  reduce 191 (src line 1068)
+	.  reduce 191 (src line 1070)
 
 
 state 382
 	primary_key_order:  DESC.    (192)
 
-	.  reduce 192 (src line 1072)
+	.  reduce 192 (src line 1074)
 
 
 state 383
@@ -7010,13 +7010,13 @@ state 384
 state 385
 	signed_number:  '+' numeric_literal.    (193)
 
-	.  reduce 193 (src line 1078)
+	.  reduce 193 (src line 1080)
 
 
 state 386
 	signed_number:  '-' numeric_literal.    (194)
 
-	.  reduce 194 (src line 1083)
+	.  reduce 194 (src line 1085)
 
 
 state 387
@@ -7098,13 +7098,13 @@ state 388
 state 389
 	insert_rows:  insert_rows ',' '(' expr_list ')'.    (213)
 
-	.  reduce 213 (src line 1189)
+	.  reduce 213 (src line 1197)
 
 
 state 390
 	paren_update_list:  '(' column_name_list ')' '=' '(' expr_list ')'.    (220)
 
-	.  reduce 220 (src line 1240)
+	.  reduce 220 (src line 1248)
 
 
 state 391
@@ -7218,32 +7218,32 @@ state 394
 	nulls: .    (61)
 
 	NULLS  shift 410
-	.  reduce 61 (src line 483)
+	.  reduce 61 (src line 485)
 
 	nulls  goto 409
 
 state 395
 	asc_desc_opt:  ASC.    (59)
 
-	.  reduce 59 (src line 473)
+	.  reduce 59 (src line 475)
 
 
 state 396
 	asc_desc_opt:  DESC.    (60)
 
-	.  reduce 60 (src line 477)
+	.  reduce 60 (src line 479)
 
 
 state 397
 	join_constraint:  USING '(' column_name_list ')'.    (46)
 
-	.  reduce 46 (src line 405)
+	.  reduce 46 (src line 407)
 
 
 state 398
 	filter_opt:  FILTER '(' WHERE expr ')'.    (157)
 
-	.  reduce 157 (src line 914)
+	.  reduce 157 (src line 916)
 
 
 state 399
@@ -7258,25 +7258,25 @@ state 399
 state 400
 	table_constraint:  constraint_name UNIQUE '(' column_name_list ')'.    (206)
 
-	.  reduce 206 (src line 1145)
+	.  reduce 206 (src line 1153)
 
 
 state 401
 	table_constraint:  constraint_name CHECK '(' expr ')'.    (207)
 
-	.  reduce 207 (src line 1149)
+	.  reduce 207 (src line 1157)
 
 
 state 402
 	column_constraint:  constraint_name CHECK '(' expr ')'.    (182)
 
-	.  reduce 182 (src line 1028)
+	.  reduce 182 (src line 1030)
 
 
 state 403
 	column_constraint:  constraint_name DEFAULT '(' expr ')'.    (183)
 
-	.  reduce 183 (src line 1032)
+	.  reduce 183 (src line 1034)
 
 
 state 404
@@ -7320,7 +7320,7 @@ state 405
 
 	STORED  shift 414
 	VIRTUAL  shift 415
-	.  reduce 198 (src line 1105)
+	.  reduce 198 (src line 1107)
 
 	is_stored  goto 413
 
@@ -7385,7 +7385,7 @@ state 406
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 66 (src line 505)
+	.  reduce 66 (src line 507)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -7453,7 +7453,7 @@ state 407
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 67 (src line 509)
+	.  reduce 67 (src line 511)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -7463,13 +7463,13 @@ state 407
 state 408
 	order_list:  order_list ',' ordering_term.    (56)
 
-	.  reduce 56 (src line 456)
+	.  reduce 56 (src line 458)
 
 
 state 409
 	ordering_term:  expr asc_desc_opt nulls.    (57)
 
-	.  reduce 57 (src line 462)
+	.  reduce 57 (src line 464)
 
 
 state 410
@@ -7484,7 +7484,7 @@ state 410
 state 411
 	table_constraint:  constraint_name PRIMARY KEY '(' column_name_list ')'.    (205)
 
-	.  reduce 205 (src line 1140)
+	.  reduce 205 (src line 1148)
 
 
 state 412
@@ -7559,31 +7559,31 @@ state 412
 state 413
 	column_constraint:  constraint_name AS '(' expr ')' is_stored.    (187)
 
-	.  reduce 187 (src line 1048)
+	.  reduce 187 (src line 1050)
 
 
 state 414
 	is_stored:  STORED.    (199)
 
-	.  reduce 199 (src line 1109)
+	.  reduce 199 (src line 1111)
 
 
 state 415
 	is_stored:  VIRTUAL.    (200)
 
-	.  reduce 200 (src line 1113)
+	.  reduce 200 (src line 1115)
 
 
 state 416
 	nulls:  NULLS FIRST.    (62)
 
-	.  reduce 62 (src line 487)
+	.  reduce 62 (src line 489)
 
 
 state 417
 	nulls:  NULLS LAST.    (63)
 
-	.  reduce 63 (src line 491)
+	.  reduce 63 (src line 493)
 
 
 state 418
@@ -7592,14 +7592,14 @@ state 418
 
 	STORED  shift 414
 	VIRTUAL  shift 415
-	.  reduce 198 (src line 1105)
+	.  reduce 198 (src line 1107)
 
 	is_stored  goto 419
 
 state 419
 	column_constraint:  constraint_name GENERATED ALWAYS AS '(' expr ')' is_stored.    (186)
 
-	.  reduce 186 (src line 1044)
+	.  reduce 186 (src line 1046)
 
 
 112 terminals, 82 nonterminals

--- a/y.output
+++ b/y.output
@@ -34,7 +34,7 @@ state 1
 state 2
 	start:  stmts.    (1)
 
-	.  reduce 1 (src line 161)
+	.  reduce 1 (src line 159)
 
 
 state 3
@@ -42,7 +42,7 @@ state 3
 	semicolon_opt: .    (13)
 
 	';'  shift 21
-	.  reduce 13 (src line 226)
+	.  reduce 13 (src line 224)
 
 	semicolon_opt  goto 20
 
@@ -52,26 +52,26 @@ state 4
 	semicolon_opt: .    (13)
 
 	';'  shift 23
-	.  reduce 13 (src line 226)
+	.  reduce 13 (src line 224)
 
 	semicolon_opt  goto 22
 
 state 5
 	single_stmt:  select_stmt.    (4)
 
-	.  reduce 4 (src line 176)
+	.  reduce 4 (src line 174)
 
 
 state 6
 	single_stmt:  create_table_stmt.    (5)
 
-	.  reduce 5 (src line 181)
+	.  reduce 5 (src line 179)
 
 
 state 7
 	multi_stmts:  multi_stmt.    (6)
 
-	.  reduce 6 (src line 187)
+	.  reduce 6 (src line 185)
 
 
 state 8
@@ -80,7 +80,7 @@ state 8
 
 	DISTINCT  shift 25
 	ALL  shift 26
-	.  reduce 16 (src line 247)
+	.  reduce 16 (src line 245)
 
 	distinct_opt  goto 24
 
@@ -94,31 +94,31 @@ state 9
 state 10
 	multi_stmt:  insert_stmt.    (8)
 
-	.  reduce 8 (src line 198)
+	.  reduce 8 (src line 196)
 
 
 state 11
 	multi_stmt:  delete_stmt.    (9)
 
-	.  reduce 9 (src line 204)
+	.  reduce 9 (src line 202)
 
 
 state 12
 	multi_stmt:  update_stmt.    (10)
 
-	.  reduce 10 (src line 209)
+	.  reduce 10 (src line 207)
 
 
 state 13
 	multi_stmt:  grant_stmt.    (11)
 
-	.  reduce 11 (src line 214)
+	.  reduce 11 (src line 212)
 
 
 state 14
 	multi_stmt:  revoke_stmt.    (12)
 
-	.  reduce 12 (src line 219)
+	.  reduce 12 (src line 217)
 
 
 state 15
@@ -170,19 +170,19 @@ state 19
 state 20
 	stmts:  single_stmt semicolon_opt.    (2)
 
-	.  reduce 2 (src line 165)
+	.  reduce 2 (src line 163)
 
 
 state 21
 	semicolon_opt:  ';'.    (14)
 
-	.  reduce 14 (src line 228)
+	.  reduce 14 (src line 226)
 
 
 state 22
 	stmts:  multi_stmts semicolon_opt.    (3)
 
-	.  reduce 3 (src line 170)
+	.  reduce 3 (src line 168)
 
 
 state 23
@@ -194,7 +194,7 @@ state 23
 	UPDATE  shift 17
 	GRANT  shift 18
 	REVOKE  shift 19
-	.  reduce 14 (src line 228)
+	.  reduce 14 (src line 226)
 
 	multi_stmt  goto 39
 	insert_stmt  goto 10
@@ -244,13 +244,13 @@ state 24
 state 25
 	distinct_opt:  DISTINCT.    (17)
 
-	.  reduce 17 (src line 251)
+	.  reduce 17 (src line 249)
 
 
 state 26
 	distinct_opt:  ALL.    (18)
 
-	.  reduce 18 (src line 255)
+	.  reduce 18 (src line 253)
 
 
 state 27
@@ -291,13 +291,13 @@ state 30
 state 31
 	table_name:  identifier.    (68)
 
-	.  reduce 68 (src line 517)
+	.  reduce 68 (src line 515)
 
 
 state 32
 	identifier:  IDENTIFIER.    (231)
 
-	.  reduce 231 (src line 1330)
+	.  reduce 231 (src line 1342)
 
 
 state 33
@@ -312,25 +312,25 @@ state 33
 state 34
 	privileges:  privilege.    (226)
 
-	.  reduce 226 (src line 1297)
+	.  reduce 226 (src line 1309)
 
 
 state 35
 	privilege:  INSERT.    (228)
 
-	.  reduce 228 (src line 1315)
+	.  reduce 228 (src line 1327)
 
 
 state 36
 	privilege:  UPDATE.    (229)
 
-	.  reduce 229 (src line 1320)
+	.  reduce 229 (src line 1332)
 
 
 state 37
 	privilege:  DELETE.    (230)
 
-	.  reduce 230 (src line 1324)
+	.  reduce 230 (src line 1336)
 
 
 state 38
@@ -345,7 +345,7 @@ state 38
 state 39
 	multi_stmts:  multi_stmts ';' multi_stmt.    (7)
 
-	.  reduce 7 (src line 192)
+	.  reduce 7 (src line 190)
 
 
 state 40
@@ -361,13 +361,13 @@ state 40
 state 41
 	select_column_list:  select_column.    (19)
 
-	.  reduce 19 (src line 261)
+	.  reduce 19 (src line 259)
 
 
 state 42
 	select_column:  '*'.    (21)
 
-	.  reduce 21 (src line 271)
+	.  reduce 21 (src line 269)
 
 
 state 43
@@ -435,7 +435,7 @@ state 43
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 24 (src line 285)
+	.  reduce 24 (src line 283)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -456,13 +456,13 @@ state 44
 state 45
 	expr:  literal_value.    (69)
 
-	.  reduce 69 (src line 524)
+	.  reduce 69 (src line 522)
 
 
 state 46
 	expr:  column_name.    (70)
 
-	.  reduce 70 (src line 526)
+	.  reduce 70 (src line 524)
 
 
 state 47
@@ -593,7 +593,7 @@ state 50
 	'+'  shift 48
 	'-'  shift 47
 	'~'  shift 49
-	.  reduce 158 (src line 922)
+	.  reduce 158 (src line 920)
 
 	expr  goto 127
 	literal_value  goto 45
@@ -648,13 +648,13 @@ state 51
 state 52
 	expr:  subquery.    (104)
 
-	.  reduce 104 (src line 664)
+	.  reduce 104 (src line 662)
 
 
 state 53
 	expr:  exists_subquery.    (105)
 
-	.  reduce 105 (src line 668)
+	.  reduce 105 (src line 666)
 
 
 state 54
@@ -667,13 +667,13 @@ state 54
 state 55
 	expr:  function_call_keyword.    (107)
 
-	.  reduce 107 (src line 676)
+	.  reduce 107 (src line 674)
 
 
 state 56
 	expr:  function_call_generic.    (108)
 
-	.  reduce 108 (src line 677)
+	.  reduce 108 (src line 675)
 
 
 state 57
@@ -683,44 +683,44 @@ state 57
 	function_call_generic:  identifier.'(' '*' ')' filter_opt 
 
 	'('  shift 131
-	'.'  reduce 68 (src line 517)
-	.  reduce 115 (src line 714)
+	'.'  reduce 68 (src line 515)
+	.  reduce 115 (src line 712)
 
 
 state 58
 	literal_value:  numeric_literal.    (109)
 
-	.  reduce 109 (src line 680)
+	.  reduce 109 (src line 678)
 
 
 state 59
 	literal_value:  STRING.    (110)
 
-	.  reduce 110 (src line 685)
+	.  reduce 110 (src line 683)
 
 
 state 60
 	literal_value:  BLOBVAL.    (111)
 
-	.  reduce 111 (src line 693)
+	.  reduce 111 (src line 691)
 
 
 state 61
 	literal_value:  TRUE.    (112)
 
-	.  reduce 112 (src line 700)
+	.  reduce 112 (src line 698)
 
 
 state 62
 	literal_value:  FALSE.    (113)
 
-	.  reduce 113 (src line 704)
+	.  reduce 113 (src line 702)
 
 
 state 63
 	literal_value:  NULL.    (114)
 
-	.  reduce 114 (src line 708)
+	.  reduce 114 (src line 706)
 
 
 state 64
@@ -756,19 +756,19 @@ state 67
 state 68
 	numeric_literal:  INTEGRAL.    (195)
 
-	.  reduce 195 (src line 1092)
+	.  reduce 195 (src line 1100)
 
 
 state 69
 	numeric_literal:  FLOAT.    (196)
 
-	.  reduce 196 (src line 1097)
+	.  reduce 196 (src line 1105)
 
 
 state 70
 	numeric_literal:  HEXNUM.    (197)
 
-	.  reduce 197 (src line 1101)
+	.  reduce 197 (src line 1109)
 
 
 state 71
@@ -785,7 +785,7 @@ state 72
 
 	'('  shift 140
 	DEFAULT  shift 139
-	.  reduce 210 (src line 1181)
+	.  reduce 210 (src line 1193)
 
 	column_name_list_opt  goto 138
 
@@ -794,7 +794,7 @@ state 73
 	where_opt: .    (47)
 
 	WHERE  shift 142
-	.  reduce 47 (src line 413)
+	.  reduce 47 (src line 411)
 
 	where_opt  goto 141
 
@@ -845,7 +845,7 @@ state 78
 	where_opt: .    (47)
 
 	WHERE  shift 142
-	.  reduce 47 (src line 413)
+	.  reduce 47 (src line 411)
 
 	where_opt  goto 153
 
@@ -903,7 +903,7 @@ state 80
 state 81
 	select_column:  expr as_column_opt.    (22)
 
-	.  reduce 22 (src line 276)
+	.  reduce 22 (src line 274)
 
 
 state 82
@@ -1542,13 +1542,13 @@ state 99
 state 100
 	expr:  expr ISNULL.    (95)
 
-	.  reduce 95 (src line 628)
+	.  reduce 95 (src line 626)
 
 
 state 101
 	expr:  expr NOTNULL.    (96)
 
-	.  reduce 96 (src line 632)
+	.  reduce 96 (src line 630)
 
 
 state 102
@@ -1625,7 +1625,7 @@ state 105
 state 106
 	as_column_opt:  col_alias.    (25)
 
-	.  reduce 25 (src line 289)
+	.  reduce 25 (src line 287)
 
 
 state 107
@@ -1641,79 +1641,79 @@ state 107
 state 108
 	cmp_op:  '='.    (118)
 
-	.  reduce 118 (src line 732)
+	.  reduce 118 (src line 730)
 
 
 state 109
 	cmp_op:  NE.    (119)
 
-	.  reduce 119 (src line 737)
+	.  reduce 119 (src line 735)
 
 
 state 110
 	cmp_op:  REGEXP.    (120)
 
-	.  reduce 120 (src line 741)
+	.  reduce 120 (src line 739)
 
 
 state 111
 	cmp_op:  GLOB.    (122)
 
-	.  reduce 122 (src line 749)
+	.  reduce 122 (src line 747)
 
 
 state 112
 	cmp_op:  MATCH.    (124)
 
-	.  reduce 124 (src line 757)
+	.  reduce 124 (src line 755)
 
 
 state 113
 	cmp_inequality_op:  '<'.    (126)
 
-	.  reduce 126 (src line 767)
+	.  reduce 126 (src line 765)
 
 
 state 114
 	cmp_inequality_op:  '>'.    (127)
 
-	.  reduce 127 (src line 772)
+	.  reduce 127 (src line 770)
 
 
 state 115
 	cmp_inequality_op:  LE.    (128)
 
-	.  reduce 128 (src line 776)
+	.  reduce 128 (src line 774)
 
 
 state 116
 	cmp_inequality_op:  GE.    (129)
 
-	.  reduce 129 (src line 780)
+	.  reduce 129 (src line 778)
 
 
 state 117
 	like_op:  LIKE.    (130)
 
-	.  reduce 130 (src line 786)
+	.  reduce 130 (src line 784)
 
 
 state 118
 	between_op:  BETWEEN.    (132)
 
-	.  reduce 132 (src line 797)
+	.  reduce 132 (src line 795)
 
 
 state 119
 	col_alias:  identifier.    (27)
 
-	.  reduce 27 (src line 298)
+	.  reduce 27 (src line 296)
 
 
 state 120
 	col_alias:  STRING.    (28)
 
-	.  reduce 28 (src line 303)
+	.  reduce 28 (src line 301)
 
 
 state 121
@@ -1757,7 +1757,7 @@ state 122
 	expr:  expr.IN col_tuple 
 	expr:  expr.NOT IN col_tuple 
 
-	.  reduce 88 (src line 596)
+	.  reduce 88 (src line 594)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -1801,7 +1801,7 @@ state 124
 	expr:  expr.IN col_tuple 
 	expr:  expr.NOT IN col_tuple 
 
-	.  reduce 89 (src line 604)
+	.  reduce 89 (src line 602)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -1838,7 +1838,7 @@ state 125
 	expr:  expr.IN col_tuple 
 	expr:  expr.NOT IN col_tuple 
 
-	.  reduce 90 (src line 608)
+	.  reduce 90 (src line 606)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -1915,7 +1915,7 @@ state 127
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 159 (src line 926)
+	.  reduce 159 (src line 924)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2040,14 +2040,14 @@ state 131
 
 	DISTINCT  shift 203
 	'*'  shift 202
-	.  reduce 150 (src line 881)
+	.  reduce 150 (src line 879)
 
 	distinct_function_opt  goto 201
 
 state 132
 	exists_subquery:  EXISTS subquery.    (143)
 
-	.  reduce 143 (src line 838)
+	.  reduce 143 (src line 836)
 
 
 state 133
@@ -2175,7 +2175,7 @@ state 140
 state 141
 	delete_stmt:  DELETE FROM table_name where_opt.    (214)
 
-	.  reduce 214 (src line 1203)
+	.  reduce 214 (src line 1215)
 
 
 state 142
@@ -2218,7 +2218,7 @@ state 143
 	where_opt: .    (47)
 
 	WHERE  shift 142
-	.  reduce 47 (src line 413)
+	.  reduce 47 (src line 411)
 
 	where_opt  goto 215
 
@@ -2227,19 +2227,19 @@ state 144
 	common_update_list:  common_update_list.',' update_expression 
 
 	','  shift 216
-	.  reduce 216 (src line 1223)
+	.  reduce 216 (src line 1235)
 
 
 state 145
 	update_list:  paren_update_list.    (217)
 
-	.  reduce 217 (src line 1228)
+	.  reduce 217 (src line 1240)
 
 
 state 146
 	common_update_list:  update_expression.    (218)
 
-	.  reduce 218 (src line 1234)
+	.  reduce 218 (src line 1246)
 
 
 state 147
@@ -2262,7 +2262,7 @@ state 148
 state 149
 	column_name:  identifier.    (115)
 
-	.  reduce 115 (src line 714)
+	.  reduce 115 (src line 712)
 
 
 state 150
@@ -2275,7 +2275,7 @@ state 150
 state 151
 	privileges:  privileges ',' privilege.    (227)
 
-	.  reduce 227 (src line 1304)
+	.  reduce 227 (src line 1316)
 
 
 state 152
@@ -2290,14 +2290,14 @@ state 153
 	group_by_opt: .    (49)
 
 	GROUP  shift 222
-	.  reduce 49 (src line 423)
+	.  reduce 49 (src line 421)
 
 	group_by_opt  goto 221
 
 state 154
 	select_column_list:  select_column_list ',' select_column.    (20)
 
-	.  reduce 20 (src line 266)
+	.  reduce 20 (src line 264)
 
 
 state 155
@@ -2305,7 +2305,7 @@ state 155
 	table_expr_list:  table_expr_list.',' table_expr 
 
 	','  shift 223
-	.  reduce 29 (src line 309)
+	.  reduce 29 (src line 307)
 
 
 state 156
@@ -2313,7 +2313,7 @@ state 156
 	join_clause:  join_clause.JOIN table_expr join_constraint 
 
 	JOIN  shift 224
-	.  reduce 30 (src line 314)
+	.  reduce 30 (src line 312)
 
 
 state 157
@@ -2321,7 +2321,7 @@ state 157
 	join_clause:  table_expr.JOIN table_expr join_constraint 
 
 	JOIN  shift 225
-	.  reduce 31 (src line 320)
+	.  reduce 31 (src line 318)
 
 
 state 158
@@ -2331,7 +2331,7 @@ state 158
 	IDENTIFIER  shift 32
 	STRING  shift 230
 	AS  shift 228
-	.  reduce 37 (src line 350)
+	.  reduce 37 (src line 348)
 
 	as_table_opt  goto 226
 	table_alias  goto 227
@@ -2391,7 +2391,7 @@ state 160
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 72 (src line 532)
+	.  reduce 72 (src line 530)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2435,7 +2435,7 @@ state 161
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 73 (src line 536)
+	.  reduce 73 (src line 534)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2476,7 +2476,7 @@ state 162
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 74 (src line 540)
+	.  reduce 74 (src line 538)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2517,7 +2517,7 @@ state 163
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 75 (src line 544)
+	.  reduce 75 (src line 542)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2558,7 +2558,7 @@ state 164
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 76 (src line 548)
+	.  reduce 76 (src line 546)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2604,7 +2604,7 @@ state 165
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 77 (src line 552)
+	.  reduce 77 (src line 550)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2650,7 +2650,7 @@ state 166
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 78 (src line 556)
+	.  reduce 78 (src line 554)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2696,7 +2696,7 @@ state 167
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 79 (src line 560)
+	.  reduce 79 (src line 558)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2742,7 +2742,7 @@ state 168
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 80 (src line 564)
+	.  reduce 80 (src line 562)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2780,7 +2780,7 @@ state 169
 	expr:  expr.NOT IN col_tuple 
 
 	COLLATE  shift 104
-	.  reduce 81 (src line 568)
+	.  reduce 81 (src line 566)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2818,7 +2818,7 @@ state 170
 	expr:  expr.NOT IN col_tuple 
 
 	COLLATE  shift 104
-	.  reduce 82 (src line 572)
+	.  reduce 82 (src line 570)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2856,7 +2856,7 @@ state 171
 	expr:  expr.NOT IN col_tuple 
 
 	COLLATE  shift 104
-	.  reduce 83 (src line 576)
+	.  reduce 83 (src line 574)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2910,7 +2910,7 @@ state 172
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 84 (src line 580)
+	.  reduce 84 (src line 578)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2960,7 +2960,7 @@ state 173
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 85 (src line 584)
+	.  reduce 85 (src line 582)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3016,7 +3016,7 @@ state 174
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 86 (src line 588)
+	.  reduce 86 (src line 586)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3082,7 +3082,7 @@ state 175
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 91 (src line 612)
+	.  reduce 91 (src line 610)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3149,7 +3149,7 @@ state 176
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 92 (src line 616)
+	.  reduce 92 (src line 614)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3203,7 +3203,7 @@ state 177
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 93 (src line 620)
+	.  reduce 93 (src line 618)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3248,7 +3248,7 @@ state 178
 state 179
 	expr:  expr NOT NULL.    (97)
 
-	.  reduce 97 (src line 636)
+	.  reduce 97 (src line 634)
 
 
 state 180
@@ -3263,31 +3263,31 @@ state 180
 state 181
 	cmp_op:  NOT REGEXP.    (121)
 
-	.  reduce 121 (src line 745)
+	.  reduce 121 (src line 743)
 
 
 state 182
 	cmp_op:  NOT GLOB.    (123)
 
-	.  reduce 123 (src line 753)
+	.  reduce 123 (src line 751)
 
 
 state 183
 	cmp_op:  NOT MATCH.    (125)
 
-	.  reduce 125 (src line 761)
+	.  reduce 125 (src line 759)
 
 
 state 184
 	like_op:  NOT LIKE.    (131)
 
-	.  reduce 131 (src line 791)
+	.  reduce 131 (src line 789)
 
 
 state 185
 	between_op:  NOT BETWEEN.    (133)
 
-	.  reduce 133 (src line 802)
+	.  reduce 133 (src line 800)
 
 
 state 186
@@ -3362,13 +3362,13 @@ state 186
 state 187
 	expr:  expr COLLATE identifier.    (100)
 
-	.  reduce 100 (src line 648)
+	.  reduce 100 (src line 646)
 
 
 state 188
 	expr:  expr IN col_tuple.    (102)
 
-	.  reduce 102 (src line 656)
+	.  reduce 102 (src line 654)
 
 
 state 189
@@ -3415,25 +3415,25 @@ state 189
 state 190
 	col_tuple:  subquery.    (140)
 
-	.  reduce 140 (src line 821)
+	.  reduce 140 (src line 819)
 
 
 state 191
 	as_column_opt:  AS col_alias.    (26)
 
-	.  reduce 26 (src line 293)
+	.  reduce 26 (src line 291)
 
 
 state 192
 	select_column:  table_name '.' '*'.    (23)
 
-	.  reduce 23 (src line 280)
+	.  reduce 23 (src line 278)
 
 
 state 193
 	expr:  table_name '.' column_name.    (71)
 
-	.  reduce 71 (src line 527)
+	.  reduce 71 (src line 525)
 
 
 state 194
@@ -3452,7 +3452,7 @@ state 195
 
 	WHEN  shift 197
 	ELSE  shift 243
-	.  reduce 163 (src line 949)
+	.  reduce 163 (src line 947)
 
 	else_expr_opt  goto 241
 	when  goto 242
@@ -3460,7 +3460,7 @@ state 195
 state 196
 	when_expr_list:  when.    (161)
 
-	.  reduce 161 (src line 939)
+	.  reduce 161 (src line 937)
 
 
 state 197
@@ -3501,13 +3501,13 @@ state 197
 state 198
 	expr:  '(' expr ')'.    (101)
 
-	.  reduce 101 (src line 652)
+	.  reduce 101 (src line 650)
 
 
 state 199
 	subquery:  '(' select_stmt ')'.    (142)
 
-	.  reduce 142 (src line 831)
+	.  reduce 142 (src line 829)
 
 
 state 200
@@ -3602,7 +3602,7 @@ state 201
 	'+'  shift 48
 	'-'  shift 47
 	'~'  shift 49
-	.  reduce 154 (src line 902)
+	.  reduce 154 (src line 900)
 
 	expr  goto 240
 	literal_value  goto 45
@@ -3627,13 +3627,13 @@ state 202
 state 203
 	distinct_function_opt:  DISTINCT.    (151)
 
-	.  reduce 151 (src line 885)
+	.  reduce 151 (src line 883)
 
 
 state 204
 	exists_subquery:  NOT EXISTS subquery.    (144)
 
-	.  reduce 144 (src line 843)
+	.  reduce 144 (src line 841)
 
 
 state 205
@@ -3781,7 +3781,7 @@ state 207
 	table_constraint_list_opt: .    (201)
 
 	','  shift 252
-	.  reduce 201 (src line 1121)
+	.  reduce 201 (src line 1129)
 
 	table_constraint_list  goto 253
 	table_constraint_list_opt  goto 251
@@ -3789,7 +3789,7 @@ state 207
 state 208
 	column_def_list:  column_def.    (166)
 
-	.  reduce 166 (src line 969)
+	.  reduce 166 (src line 967)
 
 
 state 209
@@ -3816,7 +3816,7 @@ state 210
 state 211
 	insert_stmt:  INSERT INTO table_name DEFAULT VALUES.    (209)
 
-	.  reduce 209 (src line 1175)
+	.  reduce 209 (src line 1187)
 
 
 state 212
@@ -3831,7 +3831,7 @@ state 212
 state 213
 	column_name_list:  column_name.    (116)
 
-	.  reduce 116 (src line 721)
+	.  reduce 116 (src line 719)
 
 
 state 214
@@ -3895,7 +3895,7 @@ state 214
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 48 (src line 417)
+	.  reduce 48 (src line 415)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -3905,7 +3905,7 @@ state 214
 state 215
 	update_stmt:  UPDATE table_name SET update_list where_opt.    (215)
 
-	.  reduce 215 (src line 1213)
+	.  reduce 215 (src line 1225)
 
 
 state 216
@@ -3983,7 +3983,7 @@ state 221
 	having_opt: .    (51)
 
 	HAVING  shift 272
-	.  reduce 51 (src line 433)
+	.  reduce 51 (src line 431)
 
 	having_opt  goto 271
 
@@ -4030,13 +4030,13 @@ state 225
 state 226
 	table_expr:  table_name as_table_opt.    (33)
 
-	.  reduce 33 (src line 331)
+	.  reduce 33 (src line 329)
 
 
 state 227
 	as_table_opt:  table_alias.    (38)
 
-	.  reduce 38 (src line 354)
+	.  reduce 38 (src line 352)
 
 
 state 228
@@ -4052,13 +4052,13 @@ state 228
 state 229
 	table_alias:  identifier.    (40)
 
-	.  reduce 40 (src line 363)
+	.  reduce 40 (src line 361)
 
 
 state 230
 	table_alias:  STRING.    (41)
 
-	.  reduce 41 (src line 368)
+	.  reduce 41 (src line 366)
 
 
 state 231
@@ -4168,7 +4168,7 @@ state 235
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 94 (src line 624)
+	.  reduce 94 (src line 622)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -4178,7 +4178,7 @@ state 235
 state 236
 	expr:  expr NOT IN col_tuple.    (103)
 
-	.  reduce 103 (src line 660)
+	.  reduce 103 (src line 658)
 
 
 state 237
@@ -4219,7 +4219,7 @@ state 237
 state 238
 	col_tuple:  '(' ')'.    (139)
 
-	.  reduce 139 (src line 816)
+	.  reduce 139 (src line 814)
 
 
 state 239
@@ -4292,7 +4292,7 @@ state 240
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 152 (src line 891)
+	.  reduce 152 (src line 889)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -4309,7 +4309,7 @@ state 241
 state 242
 	when_expr_list:  when_expr_list when.    (162)
 
-	.  reduce 162 (src line 944)
+	.  reduce 162 (src line 942)
 
 
 state 243
@@ -4440,7 +4440,7 @@ state 247
 	expr_list_opt:  expr_list.    (155)
 
 	','  shift 284
-	.  reduce 155 (src line 906)
+	.  reduce 155 (src line 904)
 
 
 state 248
@@ -4448,7 +4448,7 @@ state 248
 	filter_opt: .    (156)
 
 	FILTER  shift 296
-	.  reduce 156 (src line 912)
+	.  reduce 156 (src line 910)
 
 	filter_opt  goto 295
 
@@ -4537,7 +4537,7 @@ state 252
 
 	IDENTIFIER  shift 32
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1056)
+	.  reduce 188 (src line 1064)
 
 	column_name  goto 209
 	constraint_name  goto 302
@@ -4550,7 +4550,7 @@ state 253
 	table_constraint_list:  table_constraint_list.',' table_constraint 
 
 	','  shift 304
-	.  reduce 202 (src line 1125)
+	.  reduce 202 (src line 1133)
 
 
 state 254
@@ -4558,10 +4558,10 @@ state 254
 	column_constraints_opt: .    (175)
 	constraint_name: .    (188)
 
-	','  reduce 175 (src line 996)
-	')'  reduce 175 (src line 996)
+	','  reduce 175 (src line 994)
+	')'  reduce 175 (src line 994)
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1056)
+	.  reduce 188 (src line 1064)
 
 	constraint_name  goto 308
 	column_constraint  goto 307
@@ -4571,37 +4571,37 @@ state 254
 state 255
 	type_name:  INT.    (169)
 
-	.  reduce 169 (src line 987)
+	.  reduce 169 (src line 985)
 
 
 state 256
 	type_name:  INTEGER.    (170)
 
-	.  reduce 170 (src line 989)
+	.  reduce 170 (src line 987)
 
 
 state 257
 	type_name:  REAL.    (171)
 
-	.  reduce 171 (src line 990)
+	.  reduce 171 (src line 988)
 
 
 state 258
 	type_name:  TEXT.    (172)
 
-	.  reduce 172 (src line 991)
+	.  reduce 172 (src line 989)
 
 
 state 259
 	type_name:  BLOB.    (173)
 
-	.  reduce 173 (src line 992)
+	.  reduce 173 (src line 990)
 
 
 state 260
 	type_name:  ANY.    (174)
 
-	.  reduce 174 (src line 993)
+	.  reduce 174 (src line 991)
 
 
 state 261
@@ -4609,7 +4609,7 @@ state 261
 	insert_rows:  insert_rows.',' '(' expr_list ')' 
 
 	','  shift 309
-	.  reduce 208 (src line 1163)
+	.  reduce 208 (src line 1175)
 
 
 state 262
@@ -4660,13 +4660,13 @@ state 263
 state 264
 	column_name_list_opt:  '(' column_name_list ')'.    (211)
 
-	.  reduce 211 (src line 1185)
+	.  reduce 211 (src line 1197)
 
 
 state 265
 	common_update_list:  common_update_list ',' update_expression.    (219)
 
-	.  reduce 219 (src line 1242)
+	.  reduce 219 (src line 1254)
 
 
 state 266
@@ -4737,7 +4737,7 @@ state 267
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 221 (src line 1264)
+	.  reduce 221 (src line 1276)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -4749,13 +4749,13 @@ state 268
 	roles:  roles.',' STRING 
 
 	','  shift 313
-	.  reduce 222 (src line 1271)
+	.  reduce 222 (src line 1283)
 
 
 state 269
 	roles:  STRING.    (224)
 
-	.  reduce 224 (src line 1286)
+	.  reduce 224 (src line 1298)
 
 
 state 270
@@ -4763,7 +4763,7 @@ state 270
 	roles:  roles.',' STRING 
 
 	','  shift 313
-	.  reduce 223 (src line 1278)
+	.  reduce 223 (src line 1290)
 
 
 state 271
@@ -4771,7 +4771,7 @@ state 271
 	order_by_opt: .    (53)
 
 	ORDER  shift 315
-	.  reduce 53 (src line 443)
+	.  reduce 53 (src line 441)
 
 	order_by_opt  goto 314
 
@@ -4849,7 +4849,7 @@ state 273
 state 274
 	table_expr_list:  table_expr_list ',' table_expr.    (32)
 
-	.  reduce 32 (src line 325)
+	.  reduce 32 (src line 323)
 
 
 state 275
@@ -4858,7 +4858,7 @@ state 275
 
 	ON  shift 319
 	USING  shift 320
-	.  reduce 44 (src line 399)
+	.  reduce 44 (src line 397)
 
 	join_constraint  goto 318
 
@@ -4868,14 +4868,14 @@ state 276
 
 	ON  shift 319
 	USING  shift 320
-	.  reduce 44 (src line 399)
+	.  reduce 44 (src line 397)
 
 	join_constraint  goto 321
 
 state 277
 	as_table_opt:  AS table_alias.    (39)
 
-	.  reduce 39 (src line 358)
+	.  reduce 39 (src line 356)
 
 
 state 278
@@ -4885,7 +4885,7 @@ state 278
 	IDENTIFIER  shift 32
 	STRING  shift 230
 	AS  shift 228
-	.  reduce 37 (src line 350)
+	.  reduce 37 (src line 348)
 
 	as_table_opt  goto 322
 	table_alias  goto 227
@@ -4894,13 +4894,13 @@ state 278
 state 279
 	table_expr:  '(' table_expr_list ')'.    (35)
 
-	.  reduce 35 (src line 340)
+	.  reduce 35 (src line 338)
 
 
 state 280
 	table_expr:  '(' join_clause ')'.    (36)
 
-	.  reduce 36 (src line 344)
+	.  reduce 36 (src line 342)
 
 
 state 281
@@ -4950,7 +4950,7 @@ state 281
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 87 (src line 592)
+	.  reduce 87 (src line 590)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5004,7 +5004,7 @@ state 282
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 98 (src line 640)
+	.  reduce 98 (src line 638)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5014,7 +5014,7 @@ state 282
 state 283
 	col_tuple:  '(' expr_list ')'.    (141)
 
-	.  reduce 141 (src line 825)
+	.  reduce 141 (src line 823)
 
 
 state 284
@@ -5055,7 +5055,7 @@ state 284
 state 285
 	expr:  CASE expr_opt when_expr_list else_expr_opt END.    (99)
 
-	.  reduce 99 (src line 644)
+	.  reduce 99 (src line 642)
 
 
 state 286
@@ -5119,7 +5119,7 @@ state 286
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 164 (src line 953)
+	.  reduce 164 (src line 951)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5171,31 +5171,31 @@ state 288
 state 289
 	convert_type:  NONE.    (134)
 
-	.  reduce 134 (src line 808)
+	.  reduce 134 (src line 806)
 
 
 state 290
 	convert_type:  TEXT.    (135)
 
-	.  reduce 135 (src line 810)
+	.  reduce 135 (src line 808)
 
 
 state 291
 	convert_type:  REAL.    (136)
 
-	.  reduce 136 (src line 811)
+	.  reduce 136 (src line 809)
 
 
 state 292
 	convert_type:  INTEGER.    (137)
 
-	.  reduce 137 (src line 812)
+	.  reduce 137 (src line 810)
 
 
 state 293
 	convert_type:  NUMERIC.    (138)
 
-	.  reduce 138 (src line 813)
+	.  reduce 138 (src line 811)
 
 
 state 294
@@ -5203,14 +5203,14 @@ state 294
 	filter_opt: .    (156)
 
 	FILTER  shift 296
-	.  reduce 156 (src line 912)
+	.  reduce 156 (src line 910)
 
 	filter_opt  goto 326
 
 state 295
 	function_call_generic:  identifier '(' '*' ')' filter_opt.    (149)
 
-	.  reduce 149 (src line 872)
+	.  reduce 149 (src line 870)
 
 
 state 296
@@ -5363,19 +5363,19 @@ state 298
 state 299
 	create_table_stmt:  CREATE TABLE table_name '(' column_def_list table_constraint_list_opt ')'.    (165)
 
-	.  reduce 165 (src line 959)
+	.  reduce 165 (src line 957)
 
 
 state 300
 	column_def_list:  column_def_list ',' column_def.    (167)
 
-	.  reduce 167 (src line 974)
+	.  reduce 167 (src line 972)
 
 
 state 301
 	table_constraint_list:  ',' table_constraint.    (203)
 
-	.  reduce 203 (src line 1131)
+	.  reduce 203 (src line 1139)
 
 
 state 302
@@ -5402,7 +5402,7 @@ state 304
 	constraint_name: .    (188)
 
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1056)
+	.  reduce 188 (src line 1064)
 
 	constraint_name  goto 302
 	table_constraint  goto 335
@@ -5410,7 +5410,7 @@ state 304
 state 305
 	column_def:  column_name type_name column_constraints_opt.    (168)
 
-	.  reduce 168 (src line 980)
+	.  reduce 168 (src line 978)
 
 
 state 306
@@ -5418,10 +5418,10 @@ state 306
 	column_constraints:  column_constraints.column_constraint 
 	constraint_name: .    (188)
 
-	','  reduce 176 (src line 1000)
-	')'  reduce 176 (src line 1000)
+	','  reduce 176 (src line 998)
+	')'  reduce 176 (src line 998)
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1056)
+	.  reduce 188 (src line 1064)
 
 	constraint_name  goto 308
 	column_constraint  goto 336
@@ -5429,7 +5429,7 @@ state 306
 state 307
 	column_constraints:  column_constraint.    (177)
 
-	.  reduce 177 (src line 1006)
+	.  reduce 177 (src line 1004)
 
 
 state 308
@@ -5472,7 +5472,7 @@ state 310
 state 311
 	column_name_list:  column_name_list ',' column_name.    (117)
 
-	.  reduce 117 (src line 726)
+	.  reduce 117 (src line 724)
 
 
 state 312
@@ -5494,7 +5494,7 @@ state 314
 	limit_opt: .    (64)
 
 	LIMIT  shift 349
-	.  reduce 64 (src line 499)
+	.  reduce 64 (src line 497)
 
 	limit_opt  goto 348
 
@@ -5566,7 +5566,7 @@ state 316
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 52 (src line 437)
+	.  reduce 52 (src line 435)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5578,13 +5578,13 @@ state 317
 	expr_list:  expr_list.',' expr 
 
 	','  shift 284
-	.  reduce 50 (src line 427)
+	.  reduce 50 (src line 425)
 
 
 state 318
 	join_clause:  join_clause JOIN table_expr join_constraint.    (43)
 
-	.  reduce 43 (src line 386)
+	.  reduce 43 (src line 384)
 
 
 state 319
@@ -5632,13 +5632,13 @@ state 320
 state 321
 	join_clause:  table_expr JOIN table_expr join_constraint.    (42)
 
-	.  reduce 42 (src line 374)
+	.  reduce 42 (src line 372)
 
 
 state 322
 	table_expr:  '(' select_stmt ')' as_table_opt.    (34)
 
-	.  reduce 34 (src line 336)
+	.  reduce 34 (src line 334)
 
 
 state 323
@@ -5702,7 +5702,7 @@ state 323
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 153 (src line 896)
+	.  reduce 153 (src line 894)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5770,7 +5770,7 @@ state 324
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 160 (src line 932)
+	.  reduce 160 (src line 930)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5780,13 +5780,13 @@ state 324
 state 325
 	expr:  CAST '(' expr AS convert_type ')'.    (106)
 
-	.  reduce 106 (src line 672)
+	.  reduce 106 (src line 670)
 
 
 state 326
 	function_call_generic:  identifier '(' distinct_function_opt expr_list_opt ')' filter_opt.    (148)
 
-	.  reduce 148 (src line 864)
+	.  reduce 148 (src line 862)
 
 
 state 327
@@ -5799,13 +5799,13 @@ state 327
 state 328
 	function_call_keyword:  GLOB '(' expr ',' expr ')'.    (145)
 
-	.  reduce 145 (src line 849)
+	.  reduce 145 (src line 847)
 
 
 state 329
 	function_call_keyword:  LIKE '(' expr ',' expr ')'.    (146)
 
-	.  reduce 146 (src line 854)
+	.  reduce 146 (src line 852)
 
 
 state 330
@@ -5867,19 +5867,19 @@ state 333
 state 334
 	constraint_name:  CONSTRAINT identifier.    (189)
 
-	.  reduce 189 (src line 1060)
+	.  reduce 189 (src line 1068)
 
 
 state 335
 	table_constraint_list:  table_constraint_list ',' table_constraint.    (204)
 
-	.  reduce 204 (src line 1139)
+	.  reduce 204 (src line 1151)
 
 
 state 336
 	column_constraints:  column_constraints column_constraint.    (178)
 
-	.  reduce 178 (src line 1011)
+	.  reduce 178 (src line 1016)
 
 
 state 337
@@ -5899,7 +5899,7 @@ state 338
 state 339
 	column_constraint:  constraint_name UNIQUE.    (181)
 
-	.  reduce 181 (src line 1026)
+	.  reduce 181 (src line 1034)
 
 
 state 340
@@ -5984,7 +5984,7 @@ state 344
 state 345
 	insert_rows:  '(' expr_list ')'.    (212)
 
-	.  reduce 212 (src line 1192)
+	.  reduce 212 (src line 1204)
 
 
 state 346
@@ -6026,13 +6026,13 @@ state 346
 state 347
 	roles:  roles ',' STRING.    (225)
 
-	.  reduce 225 (src line 1291)
+	.  reduce 225 (src line 1303)
 
 
 state 348
 	select_stmt:  SELECT distinct_opt select_column_list from_clause where_opt group_by_opt having_opt order_by_opt limit_opt.    (15)
 
-	.  reduce 15 (src line 232)
+	.  reduce 15 (src line 230)
 
 
 state 349
@@ -6170,7 +6170,7 @@ state 351
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 45 (src line 403)
+	.  reduce 45 (src line 401)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -6349,14 +6349,14 @@ state 358
 
 	ASC  shift 381
 	DESC  shift 382
-	.  reduce 190 (src line 1066)
+	.  reduce 190 (src line 1074)
 
 	primary_key_order  goto 380
 
 state 359
 	column_constraint:  constraint_name NOT NULL.    (180)
 
-	.  reduce 180 (src line 1022)
+	.  reduce 180 (src line 1030)
 
 
 state 360
@@ -6432,13 +6432,13 @@ state 361
 state 362
 	column_constraint:  constraint_name DEFAULT literal_value.    (184)
 
-	.  reduce 184 (src line 1038)
+	.  reduce 184 (src line 1046)
 
 
 state 363
 	column_constraint:  constraint_name DEFAULT signed_number.    (185)
 
-	.  reduce 185 (src line 1042)
+	.  reduce 185 (src line 1050)
 
 
 state 364
@@ -6586,7 +6586,7 @@ state 370
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 65 (src line 503)
+	.  reduce 65 (src line 501)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -6598,13 +6598,13 @@ state 371
 	order_list:  order_list.',' ordering_term 
 
 	','  shift 393
-	.  reduce 54 (src line 447)
+	.  reduce 54 (src line 445)
 
 
 state 372
 	order_list:  ordering_term.    (55)
 
-	.  reduce 55 (src line 453)
+	.  reduce 55 (src line 451)
 
 
 state 373
@@ -6671,7 +6671,7 @@ state 373
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 58 (src line 471)
+	.  reduce 58 (src line 469)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -6760,7 +6760,7 @@ state 375
 state 376
 	function_call_keyword:  LIKE '(' expr ',' expr ',' expr ')'.    (147)
 
-	.  reduce 147 (src line 858)
+	.  reduce 147 (src line 856)
 
 
 state 377
@@ -6854,19 +6854,19 @@ state 379
 state 380
 	column_constraint:  constraint_name PRIMARY KEY primary_key_order.    (179)
 
-	.  reduce 179 (src line 1017)
+	.  reduce 179 (src line 1025)
 
 
 state 381
 	primary_key_order:  ASC.    (191)
 
-	.  reduce 191 (src line 1070)
+	.  reduce 191 (src line 1078)
 
 
 state 382
 	primary_key_order:  DESC.    (192)
 
-	.  reduce 192 (src line 1074)
+	.  reduce 192 (src line 1082)
 
 
 state 383
@@ -7010,13 +7010,13 @@ state 384
 state 385
 	signed_number:  '+' numeric_literal.    (193)
 
-	.  reduce 193 (src line 1080)
+	.  reduce 193 (src line 1088)
 
 
 state 386
 	signed_number:  '-' numeric_literal.    (194)
 
-	.  reduce 194 (src line 1085)
+	.  reduce 194 (src line 1093)
 
 
 state 387
@@ -7098,13 +7098,13 @@ state 388
 state 389
 	insert_rows:  insert_rows ',' '(' expr_list ')'.    (213)
 
-	.  reduce 213 (src line 1197)
+	.  reduce 213 (src line 1209)
 
 
 state 390
 	paren_update_list:  '(' column_name_list ')' '=' '(' expr_list ')'.    (220)
 
-	.  reduce 220 (src line 1248)
+	.  reduce 220 (src line 1260)
 
 
 state 391
@@ -7218,32 +7218,32 @@ state 394
 	nulls: .    (61)
 
 	NULLS  shift 410
-	.  reduce 61 (src line 485)
+	.  reduce 61 (src line 483)
 
 	nulls  goto 409
 
 state 395
 	asc_desc_opt:  ASC.    (59)
 
-	.  reduce 59 (src line 475)
+	.  reduce 59 (src line 473)
 
 
 state 396
 	asc_desc_opt:  DESC.    (60)
 
-	.  reduce 60 (src line 479)
+	.  reduce 60 (src line 477)
 
 
 state 397
 	join_constraint:  USING '(' column_name_list ')'.    (46)
 
-	.  reduce 46 (src line 407)
+	.  reduce 46 (src line 405)
 
 
 state 398
 	filter_opt:  FILTER '(' WHERE expr ')'.    (157)
 
-	.  reduce 157 (src line 916)
+	.  reduce 157 (src line 914)
 
 
 state 399
@@ -7258,25 +7258,25 @@ state 399
 state 400
 	table_constraint:  constraint_name UNIQUE '(' column_name_list ')'.    (206)
 
-	.  reduce 206 (src line 1153)
+	.  reduce 206 (src line 1165)
 
 
 state 401
 	table_constraint:  constraint_name CHECK '(' expr ')'.    (207)
 
-	.  reduce 207 (src line 1157)
+	.  reduce 207 (src line 1169)
 
 
 state 402
 	column_constraint:  constraint_name CHECK '(' expr ')'.    (182)
 
-	.  reduce 182 (src line 1030)
+	.  reduce 182 (src line 1038)
 
 
 state 403
 	column_constraint:  constraint_name DEFAULT '(' expr ')'.    (183)
 
-	.  reduce 183 (src line 1034)
+	.  reduce 183 (src line 1042)
 
 
 state 404
@@ -7320,7 +7320,7 @@ state 405
 
 	STORED  shift 414
 	VIRTUAL  shift 415
-	.  reduce 198 (src line 1107)
+	.  reduce 198 (src line 1115)
 
 	is_stored  goto 413
 
@@ -7385,7 +7385,7 @@ state 406
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 66 (src line 507)
+	.  reduce 66 (src line 505)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -7453,7 +7453,7 @@ state 407
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 67 (src line 511)
+	.  reduce 67 (src line 509)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -7463,13 +7463,13 @@ state 407
 state 408
 	order_list:  order_list ',' ordering_term.    (56)
 
-	.  reduce 56 (src line 458)
+	.  reduce 56 (src line 456)
 
 
 state 409
 	ordering_term:  expr asc_desc_opt nulls.    (57)
 
-	.  reduce 57 (src line 464)
+	.  reduce 57 (src line 462)
 
 
 state 410
@@ -7484,7 +7484,7 @@ state 410
 state 411
 	table_constraint:  constraint_name PRIMARY KEY '(' column_name_list ')'.    (205)
 
-	.  reduce 205 (src line 1148)
+	.  reduce 205 (src line 1160)
 
 
 state 412
@@ -7559,31 +7559,31 @@ state 412
 state 413
 	column_constraint:  constraint_name AS '(' expr ')' is_stored.    (187)
 
-	.  reduce 187 (src line 1050)
+	.  reduce 187 (src line 1058)
 
 
 state 414
 	is_stored:  STORED.    (199)
 
-	.  reduce 199 (src line 1111)
+	.  reduce 199 (src line 1119)
 
 
 state 415
 	is_stored:  VIRTUAL.    (200)
 
-	.  reduce 200 (src line 1115)
+	.  reduce 200 (src line 1123)
 
 
 state 416
 	nulls:  NULLS FIRST.    (62)
 
-	.  reduce 62 (src line 489)
+	.  reduce 62 (src line 487)
 
 
 state 417
 	nulls:  NULLS LAST.    (63)
 
-	.  reduce 63 (src line 493)
+	.  reduce 63 (src line 491)
 
 
 state 418
@@ -7592,14 +7592,14 @@ state 418
 
 	STORED  shift 414
 	VIRTUAL  shift 415
-	.  reduce 198 (src line 1107)
+	.  reduce 198 (src line 1115)
 
 	is_stored  goto 419
 
 state 419
 	column_constraint:  constraint_name GENERATED ALWAYS AS '(' expr ')' is_stored.    (186)
 
-	.  reduce 186 (src line 1046)
+	.  reduce 186 (src line 1054)
 
 
 112 terminals, 82 nonterminals

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -35,8 +35,6 @@ var keywordsNotAllowed = map[string]struct{}{
 	"UNION":         {},
 }
 
-var createStmtHasPrimaryKey = false
-
 type yySymType struct {
 	yys               int
 	bool              bool
@@ -1970,11 +1968,21 @@ yydefault:
 	case 177:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
+			if _, ok := yyDollar[1].columnConstraint.(*ColumnConstraintPrimaryKey); ok {
+				if yylex.(*Lexer).createStmtHasPrimaryKey {
+					yylex.(*Lexer).AddError(&ErrMultiplePrimaryKey{})
+				} else {
+					yylex.(*Lexer).createStmtHasPrimaryKey = true
+				}
+			}
 			yyVAL.columnConstraints = []ColumnConstraint{yyDollar[1].columnConstraint}
 		}
 	case 178:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
+			if _, ok := yyDollar[2].columnConstraint.(*ColumnConstraintPrimaryKey); ok && yylex.(*Lexer).createStmtHasPrimaryKey {
+				yylex.(*Lexer).AddError(&ErrMultiplePrimaryKey{})
+			}
 			yyVAL.columnConstraints = append(yyDollar[1].columnConstraints, yyDollar[2].columnConstraint)
 		}
 	case 179:
@@ -2102,14 +2110,18 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			if _, ok := yyDollar[2].tableConstraint.(*TableConstraintPrimaryKey); ok {
-				createStmtHasPrimaryKey = true
+				if yylex.(*Lexer).createStmtHasPrimaryKey {
+					yylex.(*Lexer).AddError(&ErrMultiplePrimaryKey{})
+				} else {
+					yylex.(*Lexer).createStmtHasPrimaryKey = true
+				}
 			}
 			yyVAL.tableConstraints = []TableConstraint{yyDollar[2].tableConstraint}
 		}
 	case 204:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
-			if _, ok := yyDollar[3].tableConstraint.(*TableConstraintPrimaryKey); ok && createStmtHasPrimaryKey {
+			if _, ok := yyDollar[3].tableConstraint.(*TableConstraintPrimaryKey); ok && yylex.(*Lexer).createStmtHasPrimaryKey {
 				yylex.(*Lexer).AddError(&ErrMultiplePrimaryKey{})
 			}
 			yyVAL.tableConstraints = append(yyDollar[1].tableConstraints, yyDollar[3].tableConstraint)

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -35,6 +35,8 @@ var keywordsNotAllowed = map[string]struct{}{
 	"UNION":         {},
 }
 
+var createStmtHasPrimaryKey = false
+
 type yySymType struct {
 	yys               int
 	bool              bool
@@ -2099,11 +2101,17 @@ yydefault:
 	case 203:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
+			if _, ok := yyDollar[2].tableConstraint.(*TableConstraintPrimaryKey); ok {
+				createStmtHasPrimaryKey = true
+			}
 			yyVAL.tableConstraints = []TableConstraint{yyDollar[2].tableConstraint}
 		}
 	case 204:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
+			if _, ok := yyDollar[3].tableConstraint.(*TableConstraintPrimaryKey); ok && createStmtHasPrimaryKey {
+				yylex.(*Lexer).AddError(&ErrMultiplePrimaryKey{})
+			}
 			yyVAL.tableConstraints = append(yyDollar[1].tableConstraints, yyDollar[3].tableConstraint)
 		}
 	case 205:


### PR DESCRIPTION
This PR enforces the following rule from [SQL spec ](https://docs.tableland.xyz/sql-specification#9e191076e01b4ac5a24d684060b9dc49)in the parser: Each table in Tableland may have at most one `PRIMARY KEY`.

Besides that, it changes the behavior of how the parser handles errors. Before this PR, only syntax errors were returned by the `Parse` method and non-syntax errors were returned in the AST. That can be confusing for clients of the package and clients may forget to check for errors. So, this PR introduces the `ErrSyntaxError` type and the Parser method returns it when a syntax error occurs.