### PR TITLE
Remove date and time functions

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -79,12 +79,12 @@ var AllowedFunctions = map[string]struct{}{
 	"trunc":   {},
 
 	// date & time functions
-	"date":      {},
-	"time":      {},
-	"datetime":  {},
-	"julianday": {},
-	"unixepoch": {},
-	"strftime":  {},
+	// "date":      {},
+	// "time":      {},
+	// "datetime":  {},
+	// "julianday": {},
+	// "unixepoch": {},
+	// "strftime":  {},
 
 	// json functions
 	"json":              {},


### PR DESCRIPTION
We thought those functions were safe but it turns out there are not. You can pass the 'now' param and make them non-deterministic. We are disallowing them for the time being.