### PR TITLE
fix: allow function identifiers to be uppercase

### DIFF
--- a/grammar.y
+++ b/grammar.y
@@ -1,7 +1,10 @@
 %{
 package sqlparser
 
-import "bytes"
+import (
+  "bytes"
+  "strings"
+)
 
 var keywordsNotAllowed = map[string]struct{}{
   // We don't allow non-deterministic keywords as identifiers. 
@@ -869,17 +872,19 @@ function_call_keyword:
 function_call_generic:
   identifier '(' distinct_function_opt expr_list_opt ')' filter_opt
   {
-    if _, ok := AllowedFunctions[string($1)]; !ok {
+    lowered := strings.ToLower(string($1))
+    if _, ok := AllowedFunctions[lowered]; !ok {
       yylex.(*Lexer).AddError(&ErrNoSuchFunction{FunctionName: string($1)})
     }
-    $$ = &FuncExpr{Name: Identifier(string($1)), Distinct: $3, Args: $4, Filter: $6}
+    $$ = &FuncExpr{Name: Identifier(lowered), Distinct: $3, Args: $4, Filter: $6}
   }
 | identifier '(' '*' ')' filter_opt
   {
-    if _, ok := AllowedFunctions[string($1)]; !ok {
+    lowered := strings.ToLower(string($1))
+    if _, ok := AllowedFunctions[lowered]; !ok {
       yylex.(*Lexer).AddError(&ErrNoSuchFunction{FunctionName: string($1)})
     }
-    $$ = &FuncExpr{Name: Identifier(string($1)), Distinct: false, Args: nil, Filter: $5}
+    $$ = &FuncExpr{Name: Identifier(lowered), Distinct: false, Args: nil, Filter: $5}
   }
 ;
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -2855,8 +2855,58 @@ func TestSelectStatement(t *testing.T) {
 			},
 		},
 		{
+			name:     "function call upper",
+			stmt:     "SELECT COUNT(c1) FROM t",
+			deparsed: "select count(c1) from t",
+			expectedAST: &AST{
+				Statements: []Statement{
+					&Select{
+						SelectColumnList: SelectColumnList{
+							&AliasedSelectColumn{
+								Expr: &FuncExpr{
+									Name: "count",
+									Args: Exprs{
+										&Column{Name: "c1"},
+									},
+								},
+							},
+						},
+						From: TableExprList{
+							&AliasedTableExpr{
+								Expr: &Table{Name: "t"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:     "function call star",
 			stmt:     "SELECT count(*) FROM t",
+			deparsed: "select count(*) from t",
+			expectedAST: &AST{
+				Statements: []Statement{
+					&Select{
+						SelectColumnList: SelectColumnList{
+							&AliasedSelectColumn{
+								Expr: &FuncExpr{
+									Name: "count",
+									Args: nil,
+								},
+							},
+						},
+						From: TableExprList{
+							&AliasedTableExpr{
+								Expr: &Table{Name: "t"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "function call star upper",
+			stmt:     "SELECT COUNT(*) FROM t",
 			deparsed: "select count(*) from t",
 			expectedAST: &AST{
 				Statements: []Statement{

--- a/y.output
+++ b/y.output
@@ -297,7 +297,7 @@ state 31
 state 32
 	identifier:  IDENTIFIER.    (239)
 
-	.  reduce 239 (src line 1421)
+	.  reduce 239 (src line 1423)
 
 
 state 33
@@ -312,25 +312,25 @@ state 33
 state 34
 	privileges:  privilege.    (234)
 
-	.  reduce 234 (src line 1388)
+	.  reduce 234 (src line 1390)
 
 
 state 35
 	privilege:  INSERT.    (236)
 
-	.  reduce 236 (src line 1406)
+	.  reduce 236 (src line 1408)
 
 
 state 36
 	privilege:  UPDATE.    (237)
 
-	.  reduce 237 (src line 1411)
+	.  reduce 237 (src line 1413)
 
 
 state 37
 	privilege:  DELETE.    (238)
 
-	.  reduce 238 (src line 1415)
+	.  reduce 238 (src line 1417)
 
 
 state 38
@@ -593,7 +593,7 @@ state 50
 	'+'  shift 48
 	'-'  shift 47
 	'~'  shift 49
-	.  reduce 158 (src line 930)
+	.  reduce 158 (src line 932)
 
 	expr  goto 127
 	literal_value  goto 45
@@ -756,19 +756,19 @@ state 67
 state 68
 	numeric_literal:  INTEGRAL.    (195)
 
-	.  reduce 195 (src line 1110)
+	.  reduce 195 (src line 1112)
 
 
 state 69
 	numeric_literal:  FLOAT.    (196)
 
-	.  reduce 196 (src line 1115)
+	.  reduce 196 (src line 1117)
 
 
 state 70
 	numeric_literal:  HEXNUM.    (197)
 
-	.  reduce 197 (src line 1119)
+	.  reduce 197 (src line 1121)
 
 
 state 71
@@ -785,7 +785,7 @@ state 72
 
 	'('  shift 140
 	DEFAULT  shift 139
-	.  reduce 210 (src line 1203)
+	.  reduce 210 (src line 1205)
 
 	column_name_list_opt  goto 138
 
@@ -1915,7 +1915,7 @@ state 127
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 159 (src line 934)
+	.  reduce 159 (src line 936)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -2040,7 +2040,7 @@ state 131
 
 	DISTINCT  shift 203
 	'*'  shift 202
-	.  reduce 150 (src line 889)
+	.  reduce 150 (src line 891)
 
 	distinct_function_opt  goto 201
 
@@ -2175,7 +2175,7 @@ state 140
 state 141
 	delete_stmt:  DELETE FROM table_name where_opt.    (222)
 
-	.  reduce 222 (src line 1294)
+	.  reduce 222 (src line 1296)
 
 
 state 142
@@ -2227,19 +2227,19 @@ state 144
 	common_update_list:  common_update_list.',' update_expression 
 
 	','  shift 216
-	.  reduce 224 (src line 1314)
+	.  reduce 224 (src line 1316)
 
 
 state 145
 	update_list:  paren_update_list.    (225)
 
-	.  reduce 225 (src line 1319)
+	.  reduce 225 (src line 1321)
 
 
 state 146
 	common_update_list:  update_expression.    (226)
 
-	.  reduce 226 (src line 1325)
+	.  reduce 226 (src line 1327)
 
 
 state 147
@@ -2275,7 +2275,7 @@ state 150
 state 151
 	privileges:  privileges ',' privilege.    (235)
 
-	.  reduce 235 (src line 1395)
+	.  reduce 235 (src line 1397)
 
 
 state 152
@@ -3452,7 +3452,7 @@ state 195
 
 	WHEN  shift 197
 	ELSE  shift 243
-	.  reduce 163 (src line 957)
+	.  reduce 163 (src line 959)
 
 	else_expr_opt  goto 241
 	when  goto 242
@@ -3460,7 +3460,7 @@ state 195
 state 196
 	when_expr_list:  when.    (161)
 
-	.  reduce 161 (src line 947)
+	.  reduce 161 (src line 949)
 
 
 state 197
@@ -3602,7 +3602,7 @@ state 201
 	'+'  shift 48
 	'-'  shift 47
 	'~'  shift 49
-	.  reduce 154 (src line 910)
+	.  reduce 154 (src line 912)
 
 	expr  goto 240
 	literal_value  goto 45
@@ -3627,7 +3627,7 @@ state 202
 state 203
 	distinct_function_opt:  DISTINCT.    (151)
 
-	.  reduce 151 (src line 893)
+	.  reduce 151 (src line 895)
 
 
 state 204
@@ -3781,7 +3781,7 @@ state 207
 	table_constraint_list_opt: .    (201)
 
 	','  shift 252
-	.  reduce 201 (src line 1139)
+	.  reduce 201 (src line 1141)
 
 	table_constraint_list  goto 253
 	table_constraint_list_opt  goto 251
@@ -3789,7 +3789,7 @@ state 207
 state 208
 	column_def_list:  column_def.    (166)
 
-	.  reduce 166 (src line 977)
+	.  reduce 166 (src line 979)
 
 
 state 209
@@ -3816,7 +3816,7 @@ state 210
 state 211
 	insert_stmt:  INSERT INTO table_name DEFAULT VALUES.    (209)
 
-	.  reduce 209 (src line 1197)
+	.  reduce 209 (src line 1199)
 
 
 state 212
@@ -3905,7 +3905,7 @@ state 214
 state 215
 	update_stmt:  UPDATE table_name SET update_list where_opt.    (223)
 
-	.  reduce 223 (src line 1304)
+	.  reduce 223 (src line 1306)
 
 
 state 216
@@ -4292,7 +4292,7 @@ state 240
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 152 (src line 899)
+	.  reduce 152 (src line 901)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -4309,7 +4309,7 @@ state 241
 state 242
 	when_expr_list:  when_expr_list when.    (162)
 
-	.  reduce 162 (src line 952)
+	.  reduce 162 (src line 954)
 
 
 state 243
@@ -4440,7 +4440,7 @@ state 247
 	expr_list_opt:  expr_list.    (155)
 
 	','  shift 284
-	.  reduce 155 (src line 914)
+	.  reduce 155 (src line 916)
 
 
 state 248
@@ -4448,7 +4448,7 @@ state 248
 	filter_opt: .    (156)
 
 	FILTER  shift 296
-	.  reduce 156 (src line 920)
+	.  reduce 156 (src line 922)
 
 	filter_opt  goto 295
 
@@ -4537,7 +4537,7 @@ state 252
 
 	IDENTIFIER  shift 32
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1074)
+	.  reduce 188 (src line 1076)
 
 	column_name  goto 209
 	constraint_name  goto 302
@@ -4550,7 +4550,7 @@ state 253
 	table_constraint_list:  table_constraint_list.',' table_constraint 
 
 	','  shift 304
-	.  reduce 202 (src line 1143)
+	.  reduce 202 (src line 1145)
 
 
 state 254
@@ -4558,10 +4558,10 @@ state 254
 	column_constraints_opt: .    (175)
 	constraint_name: .    (188)
 
-	','  reduce 175 (src line 1004)
-	')'  reduce 175 (src line 1004)
+	','  reduce 175 (src line 1006)
+	')'  reduce 175 (src line 1006)
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1074)
+	.  reduce 188 (src line 1076)
 
 	constraint_name  goto 308
 	column_constraint  goto 307
@@ -4571,37 +4571,37 @@ state 254
 state 255
 	type_name:  INT.    (169)
 
-	.  reduce 169 (src line 995)
+	.  reduce 169 (src line 997)
 
 
 state 256
 	type_name:  INTEGER.    (170)
 
-	.  reduce 170 (src line 997)
+	.  reduce 170 (src line 999)
 
 
 state 257
 	type_name:  REAL.    (171)
 
-	.  reduce 171 (src line 998)
+	.  reduce 171 (src line 1000)
 
 
 state 258
 	type_name:  TEXT.    (172)
 
-	.  reduce 172 (src line 999)
+	.  reduce 172 (src line 1001)
 
 
 state 259
 	type_name:  BLOB.    (173)
 
-	.  reduce 173 (src line 1000)
+	.  reduce 173 (src line 1002)
 
 
 state 260
 	type_name:  ANY.    (174)
 
-	.  reduce 174 (src line 1001)
+	.  reduce 174 (src line 1003)
 
 
 state 261
@@ -4611,7 +4611,7 @@ state 261
 
 	','  shift 310
 	ON  shift 313
-	.  reduce 214 (src line 1225)
+	.  reduce 214 (src line 1227)
 
 	upsert_clause_opt  goto 309
 	on_conflict_clause_list  goto 311
@@ -4665,13 +4665,13 @@ state 263
 state 264
 	column_name_list_opt:  '(' column_name_list ')'.    (211)
 
-	.  reduce 211 (src line 1207)
+	.  reduce 211 (src line 1209)
 
 
 state 265
 	common_update_list:  common_update_list ',' update_expression.    (227)
 
-	.  reduce 227 (src line 1333)
+	.  reduce 227 (src line 1335)
 
 
 state 266
@@ -4742,7 +4742,7 @@ state 267
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 229 (src line 1355)
+	.  reduce 229 (src line 1357)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -4754,13 +4754,13 @@ state 268
 	roles:  roles.',' STRING 
 
 	','  shift 317
-	.  reduce 230 (src line 1362)
+	.  reduce 230 (src line 1364)
 
 
 state 269
 	roles:  STRING.    (232)
 
-	.  reduce 232 (src line 1377)
+	.  reduce 232 (src line 1379)
 
 
 state 270
@@ -4768,7 +4768,7 @@ state 270
 	roles:  roles.',' STRING 
 
 	','  shift 317
-	.  reduce 231 (src line 1369)
+	.  reduce 231 (src line 1371)
 
 
 state 271
@@ -5124,7 +5124,7 @@ state 286
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 164 (src line 961)
+	.  reduce 164 (src line 963)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5208,14 +5208,14 @@ state 294
 	filter_opt: .    (156)
 
 	FILTER  shift 296
-	.  reduce 156 (src line 920)
+	.  reduce 156 (src line 922)
 
 	filter_opt  goto 330
 
 state 295
 	function_call_generic:  identifier '(' '*' ')' filter_opt.    (149)
 
-	.  reduce 149 (src line 880)
+	.  reduce 149 (src line 881)
 
 
 state 296
@@ -5368,19 +5368,19 @@ state 298
 state 299
 	create_table_stmt:  CREATE TABLE table_name '(' column_def_list table_constraint_list_opt ')'.    (165)
 
-	.  reduce 165 (src line 967)
+	.  reduce 165 (src line 969)
 
 
 state 300
 	column_def_list:  column_def_list ',' column_def.    (167)
 
-	.  reduce 167 (src line 982)
+	.  reduce 167 (src line 984)
 
 
 state 301
 	table_constraint_list:  ',' table_constraint.    (203)
 
-	.  reduce 203 (src line 1149)
+	.  reduce 203 (src line 1151)
 
 
 state 302
@@ -5407,7 +5407,7 @@ state 304
 	constraint_name: .    (188)
 
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1074)
+	.  reduce 188 (src line 1076)
 
 	constraint_name  goto 302
 	table_constraint  goto 339
@@ -5415,7 +5415,7 @@ state 304
 state 305
 	column_def:  column_name type_name column_constraints_opt.    (168)
 
-	.  reduce 168 (src line 988)
+	.  reduce 168 (src line 990)
 
 
 state 306
@@ -5423,10 +5423,10 @@ state 306
 	column_constraints:  column_constraints.column_constraint 
 	constraint_name: .    (188)
 
-	','  reduce 176 (src line 1008)
-	')'  reduce 176 (src line 1008)
+	','  reduce 176 (src line 1010)
+	')'  reduce 176 (src line 1010)
 	CONSTRAINT  shift 303
-	.  reduce 188 (src line 1074)
+	.  reduce 188 (src line 1076)
 
 	constraint_name  goto 308
 	column_constraint  goto 340
@@ -5434,7 +5434,7 @@ state 306
 state 307
 	column_constraints:  column_constraint.    (177)
 
-	.  reduce 177 (src line 1014)
+	.  reduce 177 (src line 1016)
 
 
 state 308
@@ -5461,7 +5461,7 @@ state 308
 state 309
 	insert_stmt:  INSERT INTO table_name column_name_list_opt VALUES insert_rows upsert_clause_opt.    (208)
 
-	.  reduce 208 (src line 1185)
+	.  reduce 208 (src line 1187)
 
 
 state 310
@@ -5476,14 +5476,14 @@ state 311
 	on_conflict_clause_list:  on_conflict_clause_list.on_conflict_clause 
 
 	ON  shift 313
-	.  reduce 215 (src line 1229)
+	.  reduce 215 (src line 1231)
 
 	on_conflict_clause  goto 349
 
 state 312
 	on_conflict_clause_list:  on_conflict_clause.    (216)
 
-	.  reduce 216 (src line 1241)
+	.  reduce 216 (src line 1243)
 
 
 state 313
@@ -5736,7 +5736,7 @@ state 327
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 153 (src line 904)
+	.  reduce 153 (src line 906)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5804,7 +5804,7 @@ state 328
 	JSON_EXTRACT_OP  shift 92
 	JSON_UNQUOTE_EXTRACT_OP  shift 93
 	COLLATE  shift 104
-	.  reduce 160 (src line 940)
+	.  reduce 160 (src line 942)
 
 	cmp_op  goto 94
 	cmp_inequality_op  goto 95
@@ -5901,19 +5901,19 @@ state 337
 state 338
 	constraint_name:  CONSTRAINT identifier.    (189)
 
-	.  reduce 189 (src line 1078)
+	.  reduce 189 (src line 1080)
 
 
 state 339
 	table_constraint_list:  table_constraint_list ',' table_constraint.    (204)
 
-	.  reduce 204 (src line 1161)
+	.  reduce 204 (src line 1163)
 
 
 state 340
 	column_constraints:  column_constraints column_constraint.    (178)
 
-	.  reduce 178 (src line 1026)
+	.  reduce 178 (src line 1028)
 
 
 state 341
@@ -5933,7 +5933,7 @@ state 342
 state 343
 	column_constraint:  constraint_name UNIQUE.    (181)
 
-	.  reduce 181 (src line 1044)
+	.  reduce 181 (src line 1046)
 
 
 state 344
@@ -6018,7 +6018,7 @@ state 348
 state 349
 	on_conflict_clause_list:  on_conflict_clause_list on_conflict_clause.    (217)
 
-	.  reduce 217 (src line 1246)
+	.  reduce 217 (src line 1248)
 
 
 state 350
@@ -6027,14 +6027,14 @@ state 350
 	conflict_target_opt: .    (220)
 
 	'('  shift 376
-	.  reduce 220 (src line 1275)
+	.  reduce 220 (src line 1277)
 
 	conflict_target_opt  goto 375
 
 state 351
 	insert_rows:  '(' expr_list ')'.    (212)
 
-	.  reduce 212 (src line 1214)
+	.  reduce 212 (src line 1216)
 
 
 state 352
@@ -6076,7 +6076,7 @@ state 352
 state 353
 	roles:  roles ',' STRING.    (233)
 
-	.  reduce 233 (src line 1382)
+	.  reduce 233 (src line 1384)
 
 
 state 354
@@ -6399,14 +6399,14 @@ state 364
 
 	ASC  shift 389
 	DESC  shift 390
-	.  reduce 190 (src line 1084)
+	.  reduce 190 (src line 1086)
 
 	primary_key_order  goto 388
 
 state 365
 	column_constraint:  constraint_name NOT NULL.    (180)
 
-	.  reduce 180 (src line 1040)
+	.  reduce 180 (src line 1042)
 
 
 state 366
@@ -6482,13 +6482,13 @@ state 367
 state 368
 	column_constraint:  constraint_name DEFAULT literal_value.    (184)
 
-	.  reduce 184 (src line 1056)
+	.  reduce 184 (src line 1058)
 
 
 state 369
 	column_constraint:  constraint_name DEFAULT signed_number.    (185)
 
-	.  reduce 185 (src line 1060)
+	.  reduce 185 (src line 1062)
 
 
 state 370
@@ -6922,19 +6922,19 @@ state 387
 state 388
 	column_constraint:  constraint_name PRIMARY KEY primary_key_order.    (179)
 
-	.  reduce 179 (src line 1035)
+	.  reduce 179 (src line 1037)
 
 
 state 389
 	primary_key_order:  ASC.    (191)
 
-	.  reduce 191 (src line 1088)
+	.  reduce 191 (src line 1090)
 
 
 state 390
 	primary_key_order:  DESC.    (192)
 
-	.  reduce 192 (src line 1092)
+	.  reduce 192 (src line 1094)
 
 
 state 391
@@ -7078,13 +7078,13 @@ state 392
 state 393
 	signed_number:  '+' numeric_literal.    (193)
 
-	.  reduce 193 (src line 1098)
+	.  reduce 193 (src line 1100)
 
 
 state 394
 	signed_number:  '-' numeric_literal.    (194)
 
-	.  reduce 194 (src line 1103)
+	.  reduce 194 (src line 1105)
 
 
 state 395
@@ -7166,7 +7166,7 @@ state 396
 state 397
 	insert_rows:  insert_rows ',' '(' expr_list ')'.    (213)
 
-	.  reduce 213 (src line 1219)
+	.  reduce 213 (src line 1221)
 
 
 state 398
@@ -7190,7 +7190,7 @@ state 399
 state 400
 	paren_update_list:  '(' column_name_list ')' '=' '(' expr_list ')'.    (228)
 
-	.  reduce 228 (src line 1339)
+	.  reduce 228 (src line 1341)
 
 
 state 401
@@ -7329,7 +7329,7 @@ state 407
 state 408
 	filter_opt:  FILTER '(' WHERE expr ')'.    (157)
 
-	.  reduce 157 (src line 924)
+	.  reduce 157 (src line 926)
 
 
 state 409
@@ -7344,25 +7344,25 @@ state 409
 state 410
 	table_constraint:  constraint_name UNIQUE '(' column_name_list ')'.    (206)
 
-	.  reduce 206 (src line 1175)
+	.  reduce 206 (src line 1177)
 
 
 state 411
 	table_constraint:  constraint_name CHECK '(' expr ')'.    (207)
 
-	.  reduce 207 (src line 1179)
+	.  reduce 207 (src line 1181)
 
 
 state 412
 	column_constraint:  constraint_name CHECK '(' expr ')'.    (182)
 
-	.  reduce 182 (src line 1048)
+	.  reduce 182 (src line 1050)
 
 
 state 413
 	column_constraint:  constraint_name DEFAULT '(' expr ')'.    (183)
 
-	.  reduce 183 (src line 1052)
+	.  reduce 183 (src line 1054)
 
 
 state 414
@@ -7406,14 +7406,14 @@ state 415
 
 	STORED  shift 427
 	VIRTUAL  shift 428
-	.  reduce 198 (src line 1125)
+	.  reduce 198 (src line 1127)
 
 	is_stored  goto 426
 
 state 416
 	on_conflict_clause:  ON CONFLICT conflict_target_opt DO NOTHING.    (218)
 
-	.  reduce 218 (src line 1252)
+	.  reduce 218 (src line 1254)
 
 
 state 417
@@ -7592,7 +7592,7 @@ state 423
 state 424
 	table_constraint:  constraint_name PRIMARY KEY '(' column_name_list ')'.    (205)
 
-	.  reduce 205 (src line 1170)
+	.  reduce 205 (src line 1172)
 
 
 state 425
@@ -7667,19 +7667,19 @@ state 425
 state 426
 	column_constraint:  constraint_name AS '(' expr ')' is_stored.    (187)
 
-	.  reduce 187 (src line 1068)
+	.  reduce 187 (src line 1070)
 
 
 state 427
 	is_stored:  STORED.    (199)
 
-	.  reduce 199 (src line 1129)
+	.  reduce 199 (src line 1131)
 
 
 state 428
 	is_stored:  VIRTUAL.    (200)
 
-	.  reduce 200 (src line 1133)
+	.  reduce 200 (src line 1135)
 
 
 state 429
@@ -7699,7 +7699,7 @@ state 429
 state 430
 	conflict_target_opt:  '(' column_name_list ')' where_opt.    (221)
 
-	.  reduce 221 (src line 1279)
+	.  reduce 221 (src line 1281)
 
 
 state 431
@@ -7720,7 +7720,7 @@ state 433
 
 	STORED  shift 427
 	VIRTUAL  shift 428
-	.  reduce 198 (src line 1125)
+	.  reduce 198 (src line 1127)
 
 	is_stored  goto 435
 
@@ -7736,13 +7736,13 @@ state 434
 state 435
 	column_constraint:  constraint_name GENERATED ALWAYS AS '(' expr ')' is_stored.    (186)
 
-	.  reduce 186 (src line 1064)
+	.  reduce 186 (src line 1066)
 
 
 state 436
 	on_conflict_clause:  ON CONFLICT conflict_target_opt DO UPDATE SET update_list where_opt.    (219)
 
-	.  reduce 219 (src line 1259)
+	.  reduce 219 (src line 1261)
 
 
 115 terminals, 86 nonterminals

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -1829,18 +1829,20 @@ yydefault:
 	case 148:
 		yyDollar = yyS[yypt-6 : yypt+1]
 		{
-			if _, ok := AllowedFunctions[string(yyDollar[1].identifier)]; !ok {
+			lowered := strings.ToLower(string(yyDollar[1].identifier))
+			if _, ok := AllowedFunctions[lowered]; !ok {
 				yylex.(*Lexer).AddError(&ErrNoSuchFunction{FunctionName: string(yyDollar[1].identifier)})
 			}
-			yyVAL.expr = &FuncExpr{Name: Identifier(string(yyDollar[1].identifier)), Distinct: yyDollar[3].bool, Args: yyDollar[4].exprs, Filter: yyDollar[6].where}
+			yyVAL.expr = &FuncExpr{Name: Identifier(lowered), Distinct: yyDollar[3].bool, Args: yyDollar[4].exprs, Filter: yyDollar[6].where}
 		}
 	case 149:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		{
-			if _, ok := AllowedFunctions[strings.ToLower(string(yyDollar[1].identifier))]; !ok {
+			lowered := strings.ToLower(string(yyDollar[1].identifier))
+			if _, ok := AllowedFunctions[lowered]; !ok {
 				yylex.(*Lexer).AddError(&ErrNoSuchFunction{FunctionName: string(yyDollar[1].identifier)})
 			}
-			yyVAL.expr = &FuncExpr{Name: Identifier(string(yyDollar[1].identifier)), Distinct: false, Args: nil, Filter: yyDollar[5].where}
+			yyVAL.expr = &FuncExpr{Name: Identifier(lowered), Distinct: false, Args: nil, Filter: yyDollar[5].where}
 		}
 	case 150:
 		yyDollar = yyS[yypt-0 : yypt+1]


### PR DESCRIPTION
# Summary

Fixes bug that was not allowing function identifiers to be uppercase

# Context

Closes #24 

# Implementation overview

Calls `strings.ToLower` on function identifier when checking to see if the function is allowed. 

# Implementation details and review orientation

na

