### PR TITLE
Allows dot inside enclosed identifiers

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -295,7 +295,7 @@ func (l *Lexer) Lex(lval *yySymType) (token int) {
 			'[': ']',
 		}
 		l.readByte() // consume opening char
-		literal := l.readIdentifier()
+		literal := l.readEnclosedIdentifier()
 		if l.ch != closingChar[ch] {
 			l.literal = literal
 			return ERROR
@@ -321,6 +321,14 @@ func (l *Lexer) Lex(lval *yySymType) (token int) {
 func (l *Lexer) readIdentifier() []byte {
 	position := l.position
 	for isLetter(l.ch) || isDigit(l.ch) {
+		l.readByte()
+	}
+	return l.input[position:l.position]
+}
+
+func (l *Lexer) readEnclosedIdentifier() []byte {
+	position := l.position
+	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '.' {
 		l.readByte()
 	}
 	return l.input[position:l.position]

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -24,8 +24,8 @@ func TestLexer(t *testing.T) {
 		CREATE TABLE INT BLOB ANY PRIMARY KEY UNIQUE CHECK DEFAULT GENERATED ALWAYS STORED VIRTUAL CONSTRAINT
 		INSERT INTO VALUES DELETE UPDATE SET CONFLICT DO NOTHING
 		GRANT TO REVOKE 
-		"doublequoteidentifier" [squarebracketsidentifier]
-	` + "`backtickidentifier`"
+		"double.quote.identifier" [square.brackets.identifier]
+	` + "`back.tick.identifier`"
 
 	expTokens := []int{
 		IDENTIFIER, INTEGRAL, FLOAT, FLOAT, STRING,


### PR DESCRIPTION
# Summary

Allows dot to be part of an enclosed identifier to enable the ENS experiment

# Context

Closes #37 

# Implementation overview

This is a Lexer issue and not a grammar (syntax) issue. The Lexer must understand that the dot is a valid character inside an identifier. I broke the `readIdentifier` method into two: one to be used when now enclosed by quotes (brackets or backticks) and the other to be used when enclosed. 

An ENS name probably supports more kinds of bytes than we're are supporting t (letters, numbers, underscore and dots). We can add those later as the experiment evolves. 
