### PR TITLE
Update golangci-lint, lint fixes

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: v1.17
+          go-version: v1.19
       - name: Checkout code
         uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, v1.18.x]
+        go-version: [1.18.x, v1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2 run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0 run
 .PHONY: lint
 
 test:

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -40,16 +40,18 @@ func TestValidateTargetTable(t *testing.T) {
 	}
 
 	for _, name := range invalidWrongFormatTests {
-		t.Run(fmt.Sprintf("invalid wrong format:%s", name), func(t *testing.T) {
-			t.Parallel()
-			table := &Table{Name: Identifier(name), IsTarget: true}
-			validTable, err := ValidateTargetTable(table)
-			require.Error(t, err)
+		func(name string) {
+			t.Run(fmt.Sprintf("invalid wrong format:%s", name), func(t *testing.T) {
+				t.Parallel()
+				table := &Table{Name: Identifier(name), IsTarget: true}
+				validTable, err := ValidateTargetTable(table)
+				require.Error(t, err)
 
-			e := &ErrTableNameWrongFormat{Name: name}
-			require.ErrorAs(t, err, &e)
-			require.Nil(t, validTable)
-		})
+				e := &ErrTableNameWrongFormat{Name: name}
+				require.ErrorAs(t, err, &e)
+				require.Nil(t, validTable)
+			})
+		}(name)
 	}
 
 	t.Run("valid table name", func(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -5105,24 +5105,30 @@ func TestCreateTableMultiplePrimaryKey(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			ast, err := Parse(tc.stmt)
-			require.Error(t, err)
-			require.Len(t, ast.Errors, 1)
+		func(tc struct {
+			name string
+			stmt string
+		},
+		) {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				ast, err := Parse(tc.stmt)
+				require.Error(t, err)
+				require.Len(t, ast.Errors, 1)
 
-			var e *ErrMultiplePrimaryKey
-			require.ErrorAs(t, ast.Errors[0], &e)
-			require.ErrorAs(t, err, &e)
+				var e *ErrMultiplePrimaryKey
+				require.ErrorAs(t, ast.Errors[0], &e)
+				require.ErrorAs(t, err, &e)
 
-			// check the stmt in sqlite to make sure sqlite also throws an error
-			db, err := sql.Open("sqlite3", "file::"+uuid.NewString()+":?mode=memory&cache=shared&_foreign_keys=on")
-			require.NoError(t, err)
+				// check the stmt in sqlite to make sure sqlite also throws an error
+				db, err := sql.Open("sqlite3", "file::"+uuid.NewString()+":?mode=memory&cache=shared&_foreign_keys=on")
+				require.NoError(t, err)
 
-			_, err = db.Exec(tc.stmt)
-			require.Error(t, err)
-			require.ErrorContains(t, err, "has more than one primary key")
-		})
+				_, err = db.Exec(tc.stmt)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "has more than one primary key")
+			})
+		}(tc)
 	}
 }
 
@@ -5184,17 +5190,23 @@ func TestRowIDReferences(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			ast, err := Parse(tc.stmt)
-			require.Error(t, err)
-			require.Len(t, ast.Errors, 1)
+		func(tc struct {
+			name string
+			stmt string
+		},
+		) {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				ast, err := Parse(tc.stmt)
+				require.Error(t, err)
+				require.Len(t, ast.Errors, 1)
 
-			var e *ErrRowIDNotAllowed
-			require.ErrorAs(t, ast.Errors[0], &e)
-			require.ErrorAs(t, err, &e)
-			require.ErrorContains(t, err, "rowid is not allowed")
-		})
+				var e *ErrRowIDNotAllowed
+				require.ErrorAs(t, ast.Errors[0], &e)
+				require.ErrorAs(t, err, &e)
+				require.ErrorContains(t, err, "rowid is not allowed")
+			})
+		}(tc)
 	}
 }
 


### PR DESCRIPTION
golangci-lint has been broken when using Go 1.19.x giving some `Can't run linter goanalysis_metalinter: goimports: can't extract issues from gofmt diff output` error. They just released an update that fixes that. It introduced some lint failures I fixed.