### PR TITLE
Support quoted identifiers and aliases

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -55,10 +55,10 @@ func (ast *AST) PrettyPrint() {
 }
 
 // Combines an ordered set of two node strings with correct delimiting
-func nodeStringConcat (left string, right string) string {
+func nodeStringConcat(left string, right string) string {
 	// If a node string starts or ends with any of these bytes the string will never
 	// need to be space delimited when being concatinated with other node strings
-	var noDelim = map[byte]struct{}{
+	noDelim := map[byte]struct{}{
 		'=': {},
 		'<': {},
 		'>': {},
@@ -79,7 +79,7 @@ func nodeStringConcat (left string, right string) string {
 		return left
 	}
 
-	if _, ok := noDelim[left[len(left) - 1]]; ok {
+	if _, ok := noDelim[left[len(left)-1]]; ok {
 		return fmt.Sprintf("%s%s", left, right)
 	}
 	if _, ok := noDelim[right[0]]; ok {
@@ -89,7 +89,7 @@ func nodeStringConcat (left string, right string) string {
 	return fmt.Sprintf("%s %s", left, right)
 }
 
-func nodeStringsConcat (strs ...string) string {
+func nodeStringsConcat(strs ...string) string {
 	var subtreeString string
 	for _, str := range strs {
 		subtreeString = nodeStringConcat(subtreeString, str)
@@ -1673,7 +1673,7 @@ func (node *ColumnConstraintGenerated) String() string {
 		b.WriteString(nodeStringsConcat(constraintName, "as(", node.Expr.String(), ")"))
 	}
 
-	var bStr = b.String()
+	bStr := b.String()
 	if node.IsStored {
 		return nodeStringsConcat(bStr, "stored")
 	}

--- a/grammar.y
+++ b/grammar.y
@@ -354,7 +354,7 @@ col_alias:
   }
 | STRING
   {
-    $$ = Identifier(string($1[1:len($1)-1]))
+    $$ = Identifier(string($1[0:len($1)]))
   }
 ;
 
@@ -409,7 +409,7 @@ table_alias:
   }
 | STRING
   {
-    $$ = Identifier(string($1[1:len($1)-1]))
+    $$ = Identifier(string($1[0:len($1)]))
   }
 ;
 

--- a/lexer.go
+++ b/lexer.go
@@ -299,6 +299,7 @@ func (l *Lexer) Lex(lval *yySymType) (token int) {
 			l.literal = literal
 			return ERROR
 		}
+		literal = append([]byte{ch}, append(literal, l.ch)...)
 		l.readByte() // consume closing char
 
 		l.literal = literal

--- a/parser_test.go
+++ b/parser_test.go
@@ -1916,7 +1916,7 @@ func TestSelectStatement(t *testing.T) {
 		{
 			name:     "simple-select-alias-table-alt-string",
 			stmt:     "SELECT * FROM t 't'",
-			deparsed: "select * from t as t",
+			deparsed: "select * from t as 't'",
 			expectedAST: &AST{
 				Statements: []Statement{
 					&Select{
@@ -1925,7 +1925,7 @@ func TestSelectStatement(t *testing.T) {
 						},
 						From: &AliasedTableExpr{
 							Expr: &Table{Name: "t", IsTarget: true},
-							As:   "t",
+							As:   "'t'",
 						},
 					},
 				},
@@ -2890,7 +2890,7 @@ func TestSelectStatement(t *testing.T) {
 		{
 			name:     "identifier delimiters",
 			stmt:     "SELECT t. a, `t2`.`b`, \"t3\".\"c\", [t4].[a]  FROM t JOIN `t2` JOIN \"t3\" JOIN [t4]",
-			deparsed: "select t.a,t2.b,t3.c,t4.a from t join t2 join t3 join t4",
+			deparsed: "select t.a,`t2`.`b`,\"t3\".\"c\",[t4].[a] from t join `t2` join \"t3\" join [t4]",
 			expectedAST: &AST{
 				Statements: []Statement{
 					&Select{
@@ -2905,25 +2905,25 @@ func TestSelectStatement(t *testing.T) {
 							},
 							&AliasedSelectColumn{
 								Expr: &Column{
-									Name: Identifier("b"),
+									Name: Identifier("`b`"),
 									TableRef: &Table{
-										Name: Identifier("t2"),
+										Name: Identifier("`t2`"),
 									},
 								},
 							},
 							&AliasedSelectColumn{
 								Expr: &Column{
-									Name: Identifier("c"),
+									Name: Identifier("\"c\""),
 									TableRef: &Table{
-										Name: Identifier("t3"),
+										Name: Identifier("\"t3\""),
 									},
 								},
 							},
 							&AliasedSelectColumn{
 								Expr: &Column{
-									Name: Identifier("a"),
+									Name: Identifier("[a]"),
 									TableRef: &Table{
-										Name: Identifier("t4"),
+										Name: Identifier("[t4]"),
 									},
 								},
 							},
@@ -2938,15 +2938,15 @@ func TestSelectStatement(t *testing.T) {
 										Expr: &Table{Name: Identifier("t"), IsTarget: true},
 									},
 									RightExpr: &AliasedTableExpr{
-										Expr: &Table{Name: Identifier("t2"), IsTarget: true},
+										Expr: &Table{Name: Identifier("`t2`"), IsTarget: true},
 									},
 								},
 								RightExpr: &AliasedTableExpr{
-									Expr: &Table{Name: Identifier("t3"), IsTarget: true},
+									Expr: &Table{Name: Identifier("\"t3\""), IsTarget: true},
 								},
 							},
 							RightExpr: &AliasedTableExpr{
-								Expr: &Table{Name: Identifier("t4"), IsTarget: true},
+								Expr: &Table{Name: Identifier("[t4]"), IsTarget: true},
 							},
 						},
 					},
@@ -3226,12 +3226,12 @@ func TestCreateTable(t *testing.T) {
 		{
 			name:         "create table backtick",
 			stmt:         "CREATE TABLE `t` (a INT);",
-			deparsed:     "create table t(a int)",
+			deparsed:     "create table `t`(a int)",
 			expectedHash: "0605f6c6705c7c1257edb2d61d94a03ad15f1d253a5a75525c6da8cda34a99ee",
 			expectedAST: &AST{
 				Statements: []Statement{
 					&CreateTable{
-						Table:       &Table{Name: "t", IsTarget: true},
+						Table:       &Table{Name: "`t`", IsTarget: true},
 						Constraints: []TableConstraint{},
 						ColumnsDef: []*ColumnDef{
 							{Column: &Column{Name: "a"}, Type: TypeIntStr, Constraints: []ColumnConstraint{}},
@@ -3243,12 +3243,12 @@ func TestCreateTable(t *testing.T) {
 		{
 			name:         "create table double quotes",
 			stmt:         "CREATE TABLE \"t\" (a INT);",
-			deparsed:     "create table t(a int)",
+			deparsed:     "create table \"t\"(a int)",
 			expectedHash: "0605f6c6705c7c1257edb2d61d94a03ad15f1d253a5a75525c6da8cda34a99ee",
 			expectedAST: &AST{
 				Statements: []Statement{
 					&CreateTable{
-						Table:       &Table{Name: "t", IsTarget: true},
+						Table:       &Table{Name: "\"t\"", IsTarget: true},
 						Constraints: []TableConstraint{},
 						ColumnsDef: []*ColumnDef{
 							{Column: &Column{Name: "a"}, Type: TypeIntStr, Constraints: []ColumnConstraint{}},
@@ -3260,12 +3260,12 @@ func TestCreateTable(t *testing.T) {
 		{
 			name:         "create table square brackets",
 			stmt:         "CREATE TABLE [t] (a INT);",
-			deparsed:     "create table t(a int)",
+			deparsed:     "create table [t](a int)",
 			expectedHash: "0605f6c6705c7c1257edb2d61d94a03ad15f1d253a5a75525c6da8cda34a99ee",
 			expectedAST: &AST{
 				Statements: []Statement{
 					&CreateTable{
-						Table:       &Table{Name: "t", IsTarget: true},
+						Table:       &Table{Name: "[t]", IsTarget: true},
 						Constraints: []TableConstraint{},
 						ColumnsDef: []*ColumnDef{
 							{Column: &Column{Name: "a"}, Type: TypeIntStr, Constraints: []ColumnConstraint{}},

--- a/parser_test.go
+++ b/parser_test.go
@@ -1538,7 +1538,7 @@ func TestSelectStatement(t *testing.T) {
 		{
 			name:     "multiple-columns",
 			stmt:     "SELECT a, t.b bcol, c1 as column, c2 as 'column2', * FROM t WHERE 1",
-			deparsed: "select a,t.b as bcol,c1 as column,c2 as column2,* from t where 1",
+			deparsed: "select a,t.b as bcol,c1 as column,c2 as 'column2',* from t where 1",
 			expectedAST: &AST{
 				Statements: []Statement{
 					&Select{
@@ -1546,7 +1546,7 @@ func TestSelectStatement(t *testing.T) {
 							&AliasedSelectColumn{Expr: &Column{Name: "a"}},
 							&AliasedSelectColumn{Expr: &Column{Name: "b", TableRef: &Table{Name: "t"}}, As: "bcol"},
 							&AliasedSelectColumn{Expr: &Column{Name: "c1"}, As: "column"},
-							&AliasedSelectColumn{Expr: &Column{Name: "c2"}, As: "column2"},
+							&AliasedSelectColumn{Expr: &Column{Name: "c2"}, As: "'column2'"},
 							&StarSelectColumn{},
 						},
 						From: &AliasedTableExpr{
@@ -1556,6 +1556,23 @@ func TestSelectStatement(t *testing.T) {
 						Where: &Where{
 							Type: WhereStr,
 							Expr: &Value{Type: IntValue, Value: []byte("1")},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "quoted-identifiers-like-drizzle",
+			stmt:     `SELECT "t"."a" as "t.a" FROM "t"`,
+			deparsed: `select "t"."a" as "t.a" from "t"`,
+			expectedAST: &AST{
+				Statements: []Statement{
+					&Select{
+						SelectColumnList: SelectColumnList{
+							&AliasedSelectColumn{Expr: &Column{Name: `"a"`, TableRef: &Table{Name: `"t"`}}, As: `"t.a"`},
+						},
+						From: &AliasedTableExpr{
+							Expr: &Table{Name: `"t"`, IsTarget: true},
 						},
 					},
 				},

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -1311,7 +1311,7 @@ yydefault:
 	case 34:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
-			yyVAL.identifier = Identifier(string(yyDollar[1].bytes[1 : len(yyDollar[1].bytes)-1]))
+			yyVAL.identifier = Identifier(string(yyDollar[1].bytes[0:len(yyDollar[1].bytes)]))
 		}
 	case 35:
 		yyDollar = yyS[yypt-2 : yypt+1]
@@ -1367,7 +1367,7 @@ yydefault:
 	case 45:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
-			yyVAL.identifier = Identifier(string(yyDollar[1].bytes[1 : len(yyDollar[1].bytes)-1]))
+			yyVAL.identifier = Identifier(string(yyDollar[1].bytes[0:len(yyDollar[1].bytes)]))
 		}
 	case 46:
 		yyDollar = yyS[yypt-4 : yypt+1]


### PR DESCRIPTION
# Summary

The parser is removing quotes from queries like: 
```
select "parts_80001_4038"."id" as "parts_80001_4038.id" from "parts_80001_4038";
```

# Implementation overview

Attempted to follow steps suggested by @brunocalza but no luck. The test I added is failing because the quotes are still being removed. I did have to update a test because in that particular case, single quotes are now preserved. It's unclear to me what the problem is now.
