### PR TITLE
fix table name validation

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -93,11 +93,25 @@ func ValidateTargetTable(table *Table) (*ValidatedTable, error) {
 		return nil, fmt.Errorf("table is not target")
 	}
 
-	if !tableNameRegEx.MatchString(table.String()) {
-		return nil, &ErrTableNameWrongFormat{Name: table.String()}
+	closingChar := map[byte]byte{
+		'"': '"',
+		'`': '`',
+		'[': ']',
 	}
 
-	parts := strings.Split(table.String(), "_")
+	tableName := table.String()
+	for start, end := range closingChar {
+		if tableName[0] == start && tableName[len(tableName)-1] == end {
+			tableName = tableName[1 : len(tableName)-1]
+			break
+		}
+	}
+
+	if !tableNameRegEx.MatchString(tableName) {
+		return nil, &ErrTableNameWrongFormat{Name: tableName}
+	}
+
+	parts := strings.Split(tableName, "_")
 	if len(parts) < 3 {
 		return nil, fmt.Errorf("not enough parts in the name")
 	}
@@ -124,11 +138,25 @@ func ValidateCreateTargetTable(table *Table) (*ValidatedCreateTable, error) {
 		return nil, fmt.Errorf("table is not target")
 	}
 
-	if !createTableNameRegEx.MatchString(table.String()) {
-		return nil, &ErrTableNameWrongFormat{Name: table.String()}
+	closingChar := map[byte]byte{
+		'"': '"',
+		'`': '`',
+		'[': ']',
 	}
 
-	parts := strings.Split(table.String(), "_")
+	tableName := table.String()
+	for start, end := range closingChar {
+		if tableName[0] == start && tableName[len(tableName)-1] == end {
+			tableName = tableName[1 : len(tableName)-1]
+			break
+		}
+	}
+
+	if !createTableNameRegEx.MatchString(tableName) {
+		return nil, &ErrTableNameWrongFormat{Name: tableName}
+	}
+
+	parts := strings.Split(tableName, "_")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("not enough parts in the name")
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -64,6 +64,16 @@ func TestValidateTargetTable(t *testing.T) {
 		require.Equal(t, "t_1_2", validTable.Name())
 	})
 
+	t.Run("valid table name enclosing", func(t *testing.T) {
+		table := &Table{Name: Identifier("[t_1_2]"), IsTarget: true}
+		validTable, err := ValidateTargetTable(table)
+		require.NoError(t, err)
+		require.Equal(t, "t", validTable.Prefix())
+		require.Equal(t, int64(1), validTable.ChainID())
+		require.Equal(t, int64(2), validTable.TokenID())
+		require.Equal(t, "[t_1_2]", validTable.Name())
+	})
+
 	t.Run("valid table name multple char", func(t *testing.T) {
 		table := &Table{Name: Identifier("table_1_2"), IsTarget: true}
 		validTable, err := ValidateTargetTable(table)
@@ -91,6 +101,15 @@ func TestValidateTargetTable(t *testing.T) {
 		require.Equal(t, "t", validTable.Prefix())
 		require.Equal(t, int64(1), validTable.ChainID())
 		require.Equal(t, "t_1", validTable.Name())
+	})
+
+	t.Run("valid create table name enclosing", func(t *testing.T) {
+		table := &Table{Name: Identifier("[t_1]"), IsTarget: true}
+		validTable, err := ValidateCreateTargetTable(table)
+		require.NoError(t, err)
+		require.Equal(t, "t", validTable.Prefix())
+		require.Equal(t, int64(1), validTable.ChainID())
+		require.Equal(t, "[t_1]", validTable.Name())
 	})
 
 	t.Run("valid create table name without prefix", func(t *testing.T) {


### PR DESCRIPTION
# Summary

Fixes table name validation to account for enclosing chars. 

# Context

Because of a recent change, the table's names are coming with enclosing chars and that was messing up the validation

# Implementation overview
- Adjusts `ValidateTargetTable` and `ValidateCreateTargetTable` to check if enclosing chars are present
- Add one test for each method
- Those methods are used by the validator

