### PR TITLE
removes group by restriction of insert with select

### DIFF
--- a/grammar.y
+++ b/grammar.y
@@ -1402,7 +1402,7 @@ insert_stmt:
     }
 
     if sel, ok := $5.(*Select); ok {
-      if sel.Having != nil || sel.GroupBy != nil {
+      if sel.Having != nil {
         yylex.(*Lexer).AddError(&ErrHavingOrGroupByIsNotAllowed{})
       }
 
@@ -1412,10 +1412,10 @@ insert_stmt:
         sel.OrderBy = append(sel.OrderBy, &OrderingTerm{Expr: &Column{Name: Identifier("rowid")}, Direction: AscStr, Nulls: NullsNil})
       }
 
-      $$ = &Insert{Table: $3, Columns: ColumnList{}, Rows: []Exprs{}, Select: sel, Upsert: $6}
+      $$ = &Insert{Table: $3, Columns: $4, Rows: []Exprs{}, Select: sel, Upsert: $6}
     } else {
       yylex.(*Lexer).AddError(&ErrCompoudSelectNotAllowed{})
-      $$ = &Insert{Table: $3, Columns: ColumnList{}, Rows: []Exprs{},  Upsert: $6}
+      $$ = &Insert{Table: $3, Columns: $4, Rows: []Exprs{},  Upsert: $6}
     }
   }
 ;

--- a/yy_parser.go
+++ b/yy_parser.go
@@ -2417,7 +2417,7 @@ yydefault:
 			}
 
 			if sel, ok := yyDollar[5].readStmt.(*Select); ok {
-				if sel.Having != nil || sel.GroupBy != nil {
+				if sel.Having != nil {
 					yylex.(*Lexer).AddError(&ErrHavingOrGroupByIsNotAllowed{})
 				}
 
@@ -2427,10 +2427,10 @@ yydefault:
 					sel.OrderBy = append(sel.OrderBy, &OrderingTerm{Expr: &Column{Name: Identifier("rowid")}, Direction: AscStr, Nulls: NullsNil})
 				}
 
-				yyVAL.insertStmt = &Insert{Table: yyDollar[3].table, Columns: ColumnList{}, Rows: []Exprs{}, Select: sel, Upsert: yyDollar[6].upsertClause}
+				yyVAL.insertStmt = &Insert{Table: yyDollar[3].table, Columns: yyDollar[4].columnList, Rows: []Exprs{}, Select: sel, Upsert: yyDollar[6].upsertClause}
 			} else {
 				yylex.(*Lexer).AddError(&ErrCompoudSelectNotAllowed{})
-				yyVAL.insertStmt = &Insert{Table: yyDollar[3].table, Columns: ColumnList{}, Rows: []Exprs{}, Upsert: yyDollar[6].upsertClause}
+				yyVAL.insertStmt = &Insert{Table: yyDollar[3].table, Columns: yyDollar[4].columnList, Rows: []Exprs{}, Upsert: yyDollar[6].upsertClause}
 			}
 		}
 	case 227:


### PR DESCRIPTION
# Summary

This PR removes the GROUP BY restriction of INSERT with SELECT queries

- It also fixes a problem that the columns of an INSERT with SELECT were not being passed 


cc @dtbuchholz 

# Context

[GSP-14](https://linear.app/tableland/issue/GSP-14/add-group-by-support-for-insert-subqueries) 


