### PR TITLE
Fix insert with select missing columns in sql output

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1832,6 +1832,7 @@ func (node *Insert) String() string {
 		return nodeStringsConcat(
 			"insert into",
 			node.Table.Name.String(),
+			node.Columns.String(),
 			node.Select.String(),
 			node.Upsert.String(),
 			returning)

--- a/parser_test.go
+++ b/parser_test.go
@@ -5327,7 +5327,7 @@ func TestInsertWithSelect(t *testing.T) {
 			stmt: `INSERT INTO voting_power (address, ft)
 			SELECT owner, SUM(COALESCE(end_time, BLOCK_NUM()) - start_time)
 			FROM pilot_sessions GROUP BY owner`,
-			deparsed: "insert into voting_power select owner,sum(coalesce(end_time,block_num())-start_time)from pilot_sessions group by owner order by rowid asc", // nolint
+			deparsed: "insert into voting_power(address,ft)select owner,sum(coalesce(end_time,block_num())-start_time)from pilot_sessions group by owner order by rowid asc", // nolint
 			expectedAST: &AST{
 				Statements: []Statement{
 					&Insert{


### PR DESCRIPTION
While working on the voting system in the garage I've been running into the bug where `INSERT INTO x SELECT` statements don't include column names. I saw that @brunocalza noticed this and added a fix in https://github.com/tablelandnetwork/go-sqlparser/pull/56 but when I tried it using the latest release of local-tableland it still wasn't working so I looked at the code and noticed that the sql that is output from the AST doesn't include the column names, so this fixes that