### PR TITLE
Fix custom function resolving in insert with select and upsert queries

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1872,7 +1872,7 @@ func (node *Insert) walkSubtree(visit Visit) error {
 		return nil
 	}
 
-	if err := Walk(visit, node.Table, node.Columns); err != nil {
+	if err := Walk(visit, node.Table, node.Columns, node.Upsert, node.Select); err != nil {
 		return err
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -5591,6 +5591,11 @@ func TestCustomFunctionResolveWriteQuery(t *testing.T) {
 			expQueries: []string{"insert into foo_1337_1 values('0xabc',100)"},
 		},
 		{
+			name:       "insert with select",
+			query:      "insert into foo_1337_1 select block_num(), 1 from foo_1337_2",
+			expQueries: []string{"insert into foo_1337_1 select 100,1 from foo_1337_2 order by rowid asc"},
+		},
+		{
 			name:       "update with custom functions",
 			query:      "update foo_1337_1 SET a=txn_hash(), b=block_num() where c in (block_num(), block_num()+1)",
 			expQueries: []string{"update foo_1337_1 set a='0xabc',b=100 where c in(100,100+1)"},

--- a/parser_test.go
+++ b/parser_test.go
@@ -5596,6 +5596,11 @@ func TestCustomFunctionResolveWriteQuery(t *testing.T) {
 			expQueries: []string{"insert into foo_1337_1 select 100,1 from foo_1337_2 order by rowid asc"},
 		},
 		{
+			name:       "upsert",
+			query:      "insert into foo_1337_1 (a) values (1) on conflict do update set a = block_num()",
+			expQueries: []string{"insert into foo_1337_1(a)values(1)on conflict do update set a=100"},
+		},
+		{
 			name:       "update with custom functions",
 			query:      "update foo_1337_1 SET a=txn_hash(), b=block_num() where c in (block_num(), block_num()+1)",
 			expQueries: []string{"update foo_1337_1 set a='0xabc',b=100 where c in(100,100+1)"},


### PR DESCRIPTION
Adds custom function resolution for Select and Upsert subnodes of an Insert node. I think we want this behavior, right?


This is the issue I was talking about btw @sanderpick where I thought `BLOCK_NUM()` wasn't working in local-tableland, I finally looked into why today and realized that it wasn't local-tableland that was the issue but that we are using it in an insert with a select-query