### PR TITLE
Increase dependabot limit to 5 in each package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: "/" 
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 5
   - package-ecosystem: "npm"
     directory: "/js"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
# Summary

This PR ups the dependabot pr limit to 5 per package.  I don't have much experience on how many dependabot prs are appropriate for the go package, so if anyone has an opinion we can change that.

# Context

https://gap.gjensidige.io/docs/github/dependabot-for-internal-packages#:~:text=By%20default%2C%20Dependabot%20opens%20a,limit%20to%20change%20this%20limit.

# Implementation overview

Our pre-monorepo npm based packages all allowed 5 dependabot PRs at a time, and this seems to me like the correct number.  Now that this repo has both the go and npm package, the default number of dependabot prs per package was affectively reduced.

# Checklist

- [x]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?