### PR TITLE
set specific go version for js build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,11 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: v1.19.x
+
       - name: Node ⬢
         uses: actions/setup-node@v2-beta
         with:


### PR DESCRIPTION
The `js-test` job is failing during the build step, as seen here: 
https://github.com/tablelandnetwork/go-sqlparser/actions/runs/8065766118/job/22032290229

As seen in the above failed action run, this is happening because a 1.21.x version of go is being used for the build. `tinygo` requires a go version between 1.18 and 1.20.  This PR fixes the version of go at 1.19.x so that it matches the version we are testing the sqlparser against.